### PR TITLE
Add simplified Defects4J test-running pipeline

### DIFF
--- a/simple_d4j_pipeline/README.md
+++ b/simple_d4j_pipeline/README.md
@@ -128,6 +128,31 @@ python eval_augmented.py   --csv data/LLM_patch_manual_evaluation.csv --repos-di
 
 For the FIB flow, `run_pipeline.py -p Time -b 18` runs a single bug.
 
+### Sweep k diverse bugs across several models
+
+`try_k.py` selects k bugs (default 30) spread across projects (deterministic
+via `--seed`), builds the shared checkouts + `buggy_<llm>` once, then runs
+generation + evaluation for each model into its own folder:
+
+```bash
+OPENAI_API_KEY=... python try_k.py --csv data/LLM_patch_manual_evaluation.csv \
+    --models gpt-5-mini gpt-5.2 gpt-5.4-mini \
+    --src-dir .. --out-dir ./results_k -k 30
+```
+
+Output:
+```
+results_k/selected_bugs.csv        the k bugs (filtered CSV driving every step)
+results_k/<model>/aug_tests/       generated tests + records/ + cost.json
+results_k/<model>/aug_results.json
+results_k/summary.json             correct/total + cost per model
+```
+
+`--src-dir` is the parent of `<Project>-<bug>/{buggy,fixed,source_*}` (copies
+checkouts and doubles as `--solutions-dir`); omit it to use `defects4j
+checkout`. Generation models are taken from `--models` and priced via
+`cost.PRICING`.
+
 ### Cost tracking & saved artifacts
 
 `gen_augmented.py` records token usage and cost for every API call:
@@ -185,6 +210,7 @@ OPENAI_ADMIN_KEY=sk-admin-... python org_costs.py --days 1
 | File | Role |
 |------|------|
 | `try_one.sh` | end-to-end smoke test of the augmented flow on one bug |
+| `try_k.py` | sweep k diverse bugs across several models into per-model folders |
 | `checkout_all.sh` | checkout buggy + fixed for all/selected bugs |
 | `import_checkouts.sh` | import existing buggy/ + fixed/ dirs into the repos/ layout |
 | `injector.py` | resolve imports + inject a method into the best test class |

--- a/simple_d4j_pipeline/README.md
+++ b/simple_d4j_pipeline/README.md
@@ -62,12 +62,18 @@ python run_pipeline.py --tests-dir ./gen_tests --repos-dir ./repos --out results
 Input is the manual-evaluation CSV (incorrect LLM patches + developer fixes).
 
 ```bash
-# 1. checkouts (shared with Flow 1)
+# 1. obtain buggy + fixed checkouts
+#    (a) fresh from Defects4J:
 bash checkout_all.sh ./repos
+#    (b) OR import pre-existing checkouts from a d4j_subjects-style tree
+#        (<SRC>/<Project>-<bug>/{buggy,fixed}); skips defects4j checkout:
+bash import_checkouts.sh .. ./repos
 
-# 2. build buggy_<llm> checkouts from the incorrect patches
+# 2. build buggy_<llm> checkouts from the incorrect patches.
+#    --solutions-dir is the SAME parent dir as import_checkouts.sh's SRC: it
+#    holds <Project>-<bug>/source_ori-* (-ori) and source_patched_rst-* (-norm).
 python prepare_patched.py --csv eval.csv --repos-dir ./repos \
-    --solutions-dir data/d4j_subjects/d4j_bugs
+    --solutions-dir ..
 #    --solutions-dir PATH    on-disk path matching /data/d4j_subjects/d4j_bugs;
 #                            copies each LLM full solution file (robust) instead
 #                            of applying the diff. STRONGLY recommended -- the CSV
@@ -100,7 +106,12 @@ To sanity-check the whole augmented flow on one bug in one command
 
 ```bash
 OPENAI_API_KEY=... bash try_one.sh Chart 16
-# bash try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL]
+# bash try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL] [PRICE_IN] [PRICE_OUT]
+#
+# If you have pre-existing checkouts + solution dirs, point SRC_DIR at their
+# parent; buggy/fixed are copied (no defects4j checkout) and SOLUTIONS_DIR
+# defaults to it:
+#   SRC_DIR=.. OPENAI_API_KEY=... bash try_one.sh Jsoup 68
 ```
 
 Defaults: `REPOS_DIR=./repos`, `TESTS_DIR=./aug_tests`,
@@ -170,6 +181,7 @@ OPENAI_ADMIN_KEY=sk-admin-... python org_costs.py --days 1
 |------|------|
 | `try_one.sh` | end-to-end smoke test of the augmented flow on one bug |
 | `checkout_all.sh` | checkout buggy + fixed for all/selected bugs |
+| `import_checkouts.sh` | import existing buggy/ + fixed/ dirs into the repos/ layout |
 | `injector.py` | resolve imports + inject a method into the best test class |
 | `run_pipeline.py` | FIB runner (inject/compile/run on buggy+fixed) |
 | `csv_data.py` | read the eval CSV; bugs with incorrect `-ori`/`-norm` patches |

--- a/simple_d4j_pipeline/README.md
+++ b/simple_d4j_pipeline/README.md
@@ -141,14 +141,17 @@ For the FIB flow, `run_pipeline.py -p Time -b 18` runs a single bug.
   **cost**. `eval_augmented.py` then merges the **eval result** into the same
   file under an `eval` key.
 
-Pricing is USD per 1M tokens. Since model prices change, pass them explicitly:
+Pricing is USD per 1M tokens. `gpt-5.4-mini` is built into `cost.PRICING`
+(input $0.75, output $4.50, cached input $0.075), so cost — including the
+cheaper rate for cached prompt tokens — is computed automatically. For other
+models, either add an entry to `cost.PRICING` or pass prices explicitly:
 
 ```bash
-python gen_augmented.py ... --price-in 0.25 --price-out 2.00
+python gen_augmented.py ... --price-in 0.75 --price-out 4.50 --price-cached 0.075
 ```
 
-Without `--price-in/--price-out` (and no entry in `cost.PRICING`), token counts
-are still recorded but cost is left `null`.
+Without any pricing (no flags and no `cost.PRICING` entry), token counts are
+still recorded but cost is left `null`.
 
 To reconcile against OpenAI's actually-billed cost, `org_costs.py` queries the
 Organization Costs API (needs an admin key):

--- a/simple_d4j_pipeline/README.md
+++ b/simple_d4j_pipeline/README.md
@@ -108,6 +108,35 @@ python eval_augmented.py   --csv data/LLM_patch_manual_evaluation.csv --repos-di
 
 For the FIB flow, `run_pipeline.py -p Time -b 18` runs a single bug.
 
+### Cost tracking & saved artifacts
+
+`gen_augmented.py` records token usage and cost for every API call:
+
+- Per-call and cumulative cost are logged live (`[cost] Chart-16: in=… out=… call=$… cumulative=$…`).
+- A cumulative cost file is written to `<tests-dir>/records/cost.json`
+  (model, prices, totals, and every call), and is resumable across runs.
+- A per-bug artifact `<tests-dir>/records/<pid>_<bug>.json` saves the
+  **prompt inputs** (developer patch, LLM patches, failing tests), the **full
+  prompt**, the **raw reply**, the **generated method**, **token usage**, and
+  **cost**. `eval_augmented.py` then merges the **eval result** into the same
+  file under an `eval` key.
+
+Pricing is USD per 1M tokens. Since model prices change, pass them explicitly:
+
+```bash
+python gen_augmented.py ... --price-in 0.25 --price-out 2.00
+```
+
+Without `--price-in/--price-out` (and no entry in `cost.PRICING`), token counts
+are still recorded but cost is left `null`.
+
+To reconcile against OpenAI's actually-billed cost, `org_costs.py` queries the
+Organization Costs API (needs an admin key):
+
+```bash
+OPENAI_ADMIN_KEY=sk-admin-... python org_costs.py --days 1
+```
+
 ### Notes
 
 - **Patch layout**: CSV patches use a normalized `src/main/java/` layout; d4j
@@ -133,6 +162,8 @@ For the FIB flow, `run_pipeline.py -p Time -b 18` runs a single bug.
 | `prepare_patched.py` | build `buggy_<llm>` checkouts |
 | `d4j_tests.py` | extract bug-triggering developer test methods |
 | `java_utils.py` | literal/comment-aware Java brace matching |
-| `gen_augmented.py` | build prompt + query OpenAI + parse the test method |
-| `eval_augmented.py` | run augmented test on buggy/fixed/buggy_<llm> |
+| `gen_augmented.py` | build prompt + query OpenAI + parse the test method; track cost; save artifacts |
+| `eval_augmented.py` | run augmented test on buggy/fixed/buggy_<llm>; merge eval into records |
+| `cost.py` | token-usage cost computation + cumulative tracker |
+| `org_costs.py` | reconcile against OpenAI's billed Organization Costs API |
 | `report_stats.py` | aggregate success stats |

--- a/simple_d4j_pipeline/README.md
+++ b/simple_d4j_pipeline/README.md
@@ -32,7 +32,10 @@ repos/<Project>_<bug>f              fixed checkout      (defects4j -v Nf)
 repos/<Project>_<bug>_<llm>         buggy + incorrect LLM patch (committed)
 ```
 
-LLM keys are `claude-sonnet-4` and `gemini-3-pro-preview` (the `-ori` columns).
+LLM keys match the CSV columns: `claude-sonnet-4-ori`, `claude-sonnet-4-norm`,
+`gemini-3-pro-preview-ori`, `gemini-3-pro-preview-norm`. Each incorrect variant
+gets its own `buggy_<llm>` checkout, and an augmented test must fail on all of
+them.
 
 ---
 
@@ -169,7 +172,7 @@ OPENAI_ADMIN_KEY=sk-admin-... python org_costs.py --days 1
 | `checkout_all.sh` | checkout buggy + fixed for all/selected bugs |
 | `injector.py` | resolve imports + inject a method into the best test class |
 | `run_pipeline.py` | FIB runner (inject/compile/run on buggy+fixed) |
-| `csv_data.py` | read the eval CSV; bugs with incorrect `-ori` patches |
+| `csv_data.py` | read the eval CSV; bugs with incorrect `-ori`/`-norm` patches |
 | `patch_utils.py` | preprocess + apply LLM patches to a checkout |
 | `prepare_patched.py` | build `buggy_<llm>` checkouts |
 | `d4j_tests.py` | extract bug-triggering developer test methods |

--- a/simple_d4j_pipeline/README.md
+++ b/simple_d4j_pipeline/README.md
@@ -84,6 +84,30 @@ python report_stats.py --results aug_results.json --by-project
 A test is **correctly augmented** when it passes on `fixed`, fails on `buggy`,
 and fails on every `buggy_<llm>` variant (≥1 variant required).
 
+### Try a single bug first
+
+To sanity-check the whole augmented flow on one bug in one command
+(checkout → build `buggy_<llm>` → generate → evaluate → print result):
+
+```bash
+OPENAI_API_KEY=... bash try_one.sh Chart 16
+# bash try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL]
+```
+
+Defaults: `REPOS_DIR=./repos`, `TESTS_DIR=./aug_tests`,
+`CSV=data/LLM_patch_manual_evaluation.csv`, `MODEL=gpt-5.4-mini`.
+The bug must have ≥1 incorrect LLM patch in the CSV.
+
+Every augmented script also takes `-b/--bug` (with `-p`) to target one bug, so
+you can run any single stage on its own, e.g.:
+
+```bash
+python prepare_patched.py --csv data/LLM_patch_manual_evaluation.csv --repos-dir ./repos -p Chart -b 16
+python eval_augmented.py   --csv data/LLM_patch_manual_evaluation.csv --repos-dir ./repos --tests-dir ./aug_tests -p Chart -b 16
+```
+
+For the FIB flow, `run_pipeline.py -p Time -b 18` runs a single bug.
+
 ### Notes
 
 - **Patch layout**: CSV patches use a normalized `src/main/java/` layout; d4j
@@ -100,6 +124,7 @@ and fails on every `buggy_<llm>` variant (≥1 variant required).
 
 | File | Role |
 |------|------|
+| `try_one.sh` | end-to-end smoke test of the augmented flow on one bug |
 | `checkout_all.sh` | checkout buggy + fixed for all/selected bugs |
 | `injector.py` | resolve imports + inject a method into the best test class |
 | `run_pipeline.py` | FIB runner (inject/compile/run on buggy+fixed) |

--- a/simple_d4j_pipeline/README.md
+++ b/simple_d4j_pipeline/README.md
@@ -1,0 +1,113 @@
+# Simplified Defects4J test-running pipeline
+
+Standalone scripts (distilled from libro) for running LLM-generated tests
+against Defects4J checkouts. There are two flows that share the same
+checkout/inject/run machinery:
+
+1. **FIB** — evaluate a bare test method as a bug reproduction
+   (fail-in-buggy / pass-in-fixed).
+2. **Augmented test** — generate and evaluate a regression test that
+   distinguishes the developer fix from both the buggy version *and* an
+   incorrect LLM patch (pass on `fixed`, fail on `buggy` and every
+   `buggy_<llm>`).
+
+All scripts are meant to run inside the Defects4J container (with the
+`defects4j` command on `PATH`).
+
+## Requirements
+
+```bash
+pip install javalang        # injection / parsing (run_pipeline, eval_augmented)
+pip install openai          # LLM generation only (gen_augmented)
+update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java   # JDK 8 for d4j
+```
+
+## On-disk layout
+
+`checkout_all.sh` and `prepare_patched.py` populate a flat `repos/` dir:
+
+```
+repos/<Project>_<bug>b              buggy checkout      (defects4j -v Nb)
+repos/<Project>_<bug>f              fixed checkout      (defects4j -v Nf)
+repos/<Project>_<bug>_<llm>         buggy + incorrect LLM patch (committed)
+```
+
+LLM keys are `claude-sonnet-4` and `gemini-3-pro-preview` (the `-ori` columns).
+
+---
+
+## Flow 1 — bug reproduction (FIB)
+
+Generated tests are one bare JUnit method per file, optionally ```` ``` ````-fenced,
+named `<Project>_<bug>_*.txt` (e.g. `Time_18_n0.txt`).
+
+```bash
+# 1. check out buggy + fixed for all bugs (or a subset of projects)
+bash checkout_all.sh ./repos               # or: bash checkout_all.sh ./repos Time Lang
+
+# 2. inject / compile / run each candidate on both versions
+python run_pipeline.py --tests-dir ./gen_tests --repos-dir ./repos --out results.json
+#    single bug:  ... -p Time -b 18
+```
+
+`success` in `results.json` = test fails on buggy and passes on fixed.
+
+---
+
+## Flow 2 — augmented regression test
+
+Input is the manual-evaluation CSV (incorrect LLM patches + developer fixes).
+
+```bash
+# 1. checkouts (shared with Flow 1)
+bash checkout_all.sh ./repos
+
+# 2. build buggy_<llm> checkouts from the incorrect patches
+python prepare_patched.py --csv eval.csv --repos-dir ./repos
+#    --include-test-changes  also apply the LLM's edits to test files (default: skip)
+#    -p Chart                restrict to one project
+
+# 3. generate one augmented test per bug via the OpenAI API
+OPENAI_API_KEY=... python gen_augmented.py \
+    --csv eval.csv --repos-dir ./repos --tests-dir ./aug_tests --model gpt-5.4-mini
+#    --save-prompts   also dump the prompt sent for each bug
+#    --overwrite      regenerate existing *_aug.txt
+
+# 4. run each augmented test on buggy / fixed / every buggy_<llm>
+python eval_augmented.py \
+    --csv eval.csv --repos-dir ./repos --tests-dir ./aug_tests --out aug_results.json
+
+# 5. stats
+python report_stats.py --results aug_results.json --by-project
+```
+
+A test is **correctly augmented** when it passes on `fixed`, fails on `buggy`,
+and fails on every `buggy_<llm>` variant (≥1 variant required).
+
+### Notes
+
+- **Patch layout**: CSV patches use a normalized `src/main/java/` layout; d4j
+  checkouts use the project's real source root. `patch_utils.py` reduces each
+  header to its package path, locates the real file, and applies hunks fuzzily,
+  so the layouts don't need to match.
+- **Production-only by default**: `prepare_patched.py` applies only
+  non-test source sections of an LLM patch. Use `--include-test-changes` to
+  also apply test-file edits.
+- **Model**: `--model` defaults to `gpt-5.4-mini`; the call uses the OpenAI
+  Responses API with a chat-completions fallback.
+
+## File map
+
+| File | Role |
+|------|------|
+| `checkout_all.sh` | checkout buggy + fixed for all/selected bugs |
+| `injector.py` | resolve imports + inject a method into the best test class |
+| `run_pipeline.py` | FIB runner (inject/compile/run on buggy+fixed) |
+| `csv_data.py` | read the eval CSV; bugs with incorrect `-ori` patches |
+| `patch_utils.py` | preprocess + apply LLM patches to a checkout |
+| `prepare_patched.py` | build `buggy_<llm>` checkouts |
+| `d4j_tests.py` | extract bug-triggering developer test methods |
+| `java_utils.py` | literal/comment-aware Java brace matching |
+| `gen_augmented.py` | build prompt + query OpenAI + parse the test method |
+| `eval_augmented.py` | run augmented test on buggy/fixed/buggy_<llm> |
+| `report_stats.py` | aggregate success stats |

--- a/simple_d4j_pipeline/README.md
+++ b/simple_d4j_pipeline/README.md
@@ -141,10 +141,12 @@ For the FIB flow, `run_pipeline.py -p Time -b 18` runs a single bug.
   **cost**. `eval_augmented.py` then merges the **eval result** into the same
   file under an `eval` key.
 
-Pricing is USD per 1M tokens. `gpt-5.4-mini` is built into `cost.PRICING`
-(input $0.75, output $4.50, cached input $0.075), so cost — including the
-cheaper rate for cached prompt tokens — is computed automatically. For other
-models, either add an entry to `cost.PRICING` or pass prices explicitly:
+Pricing is USD per 1M tokens. The gpt-5 family (`gpt-5`, `gpt-5-mini`,
+`gpt-5.1`, `gpt-5.2`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`) is built into
+`cost.PRICING` with input/output/cached-input rates, so just pick one with
+`--model` and cost — including the cheaper rate for cached prompt tokens — is
+computed automatically. For other models, add an entry to `cost.PRICING` or
+pass prices explicitly:
 
 ```bash
 python gen_augmented.py ... --price-in 0.75 --price-out 4.50 --price-cached 0.075

--- a/simple_d4j_pipeline/README.md
+++ b/simple_d4j_pipeline/README.md
@@ -82,19 +82,25 @@ python prepare_patched.py --csv eval.csv --repos-dir ./repos \
 #    --include-test-changes  also apply the LLM's edits to test files (default: skip)
 #    -p Chart                restrict to one project
 
-# 3. generate one augmented test per bug via the OpenAI API
+# 3. generate one augmented test per bug via the OpenAI API.
+#    --out-dir + --model writes to <out-dir>/<model>/aug_tests (per-model
+#    folders, same layout as try_k.py). Or use --tests-dir for an explicit path.
 OPENAI_API_KEY=... python gen_augmented.py \
-    --csv eval.csv --repos-dir ./repos --tests-dir ./aug_tests --model gpt-5.4-mini
+    --csv eval.csv --repos-dir ./repos --out-dir ./results --model gpt-5.4-mini
 #    --save-prompts   also dump the prompt sent for each bug
 #    --overwrite      regenerate existing *_aug.txt
 
 # 4. run each augmented test on buggy / fixed / every buggy_<llm>
+#    (same --out-dir/--model derives <out-dir>/<model>/aug_results.json)
 python eval_augmented.py \
-    --csv eval.csv --repos-dir ./repos --tests-dir ./aug_tests --out aug_results.json
+    --csv eval.csv --repos-dir ./repos --out-dir ./results --model gpt-5.4-mini
 
 # 5. stats
-python report_stats.py --results aug_results.json --by-project
+python report_stats.py --results ./results/gpt-5.4-mini/aug_results.json --by-project
 ```
+
+This produces `results/<model>/aug_tests/` (+ `records/`, `cost.json`) and
+`results/<model>/aug_results.json` — identical to `try_k.py`'s per-model layout.
 
 A test is **correctly augmented** when it passes on `fixed`, fails on `buggy`,
 and fails on every `buggy_<llm>` variant (≥1 variant required).

--- a/simple_d4j_pipeline/README.md
+++ b/simple_d4j_pipeline/README.md
@@ -63,7 +63,13 @@ Input is the manual-evaluation CSV (incorrect LLM patches + developer fixes).
 bash checkout_all.sh ./repos
 
 # 2. build buggy_<llm> checkouts from the incorrect patches
-python prepare_patched.py --csv eval.csv --repos-dir ./repos
+python prepare_patched.py --csv eval.csv --repos-dir ./repos \
+    --solutions-dir data/d4j_subjects/d4j_bugs
+#    --solutions-dir PATH    on-disk path matching /data/d4j_subjects/d4j_bugs;
+#                            copies each LLM full solution file (robust) instead
+#                            of applying the diff. STRONGLY recommended -- the CSV
+#                            diffs were generated against a reformatted base and
+#                            ~40% fail to apply cleanly. Diff is the fallback.
 #    --include-test-changes  also apply the LLM's edits to test files (default: skip)
 #    -p Chart                restrict to one project
 
@@ -141,8 +147,14 @@ OPENAI_ADMIN_KEY=sk-admin-... python org_costs.py --days 1
 
 - **Patch layout**: CSV patches use a normalized `src/main/java/` layout; d4j
   checkouts use the project's real source root. `patch_utils.py` reduces each
-  header to its package path, locates the real file, and applies hunks fuzzily,
-  so the layouts don't need to match.
+  header to its package path and locates the real file, so the layouts don't
+  need to match.
+- **Reformatted base**: the CSV diffs were generated against a reformatted
+  "restore" base, so applying them to the d4j buggy source fails on reflowed
+  lines (~40% of patches). Pass `--solutions-dir` so each changed file is
+  replaced wholesale with the LLM's full solution file (the solution path is
+  read from the diff's `+++` header, so the on-disk model-dir name -- e.g.
+  `source_ori-gemini-3-pro` -- need not match the CSV column name).
 - **Production-only by default**: `prepare_patched.py` applies only
   non-test source sections of an LLM patch. Use `--include-test-changes` to
   also apply test-file edits.

--- a/simple_d4j_pipeline/checkout_all.sh
+++ b/simple_d4j_pipeline/checkout_all.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Check out the buggy AND fixed versions of every Defects4J bug (or a subset)
+# into a flat repos directory, ready for the test-running pipeline.
+#
+# Layout produced:
+#   REPOS_DIR/<Project>_<bug>b   -> buggy   checkout  (defects4j checkout -v Nb)
+#   REPOS_DIR/<Project>_<bug>f   -> fixed   checkout  (defects4j checkout -v Nf)
+#
+# Usage:
+#   bash checkout_all.sh [REPOS_DIR] [PROJECT ...]
+#
+# Examples:
+#   bash checkout_all.sh ./repos                # all projects, all bugs
+#   bash checkout_all.sh ./repos Time Lang      # only Time and Lang
+#
+# Existing checkouts are skipped, so the script is safe to re-run/resume.
+
+set -u
+
+REPOS_DIR="${1:-$(pwd)/repos}"
+shift || true
+PROJECTS="$*"
+
+if [ -z "$PROJECTS" ]; then
+    PROJECTS="$(defects4j pids)"
+fi
+
+D4J_HOME="$(dirname "$(which defects4j)")/../.."
+
+mkdir -p "$REPOS_DIR"
+
+for proj in $PROJECTS; do
+    commit_db="$D4J_HOME/framework/projects/$proj/commit-db"
+    if [ ! -f "$commit_db" ]; then
+        echo "[warn] no commit-db for project '$proj', skipping" >&2
+        continue
+    fi
+    for bug in $(cut -f1 -d',' "$commit_db"); do
+        for v in b f; do
+            out="$REPOS_DIR/${proj}_${bug}${v}"
+            if [ -d "$out" ]; then
+                echo "[skip] $out already exists"
+                continue
+            fi
+            echo "[checkout] ${proj}-${bug}${v} -> $out"
+            defects4j checkout -p "$proj" -v "${bug}${v}" -w "$out"
+        done
+    done
+done
+
+echo "[done] checkouts under $REPOS_DIR"

--- a/simple_d4j_pipeline/cost.py
+++ b/simple_d4j_pipeline/cost.py
@@ -1,10 +1,11 @@
 """Per-call and cumulative OpenAI cost tracking for the generation pipeline.
 
 Cost is computed from the token usage returned on each API response
-(`usage.input_tokens` / `output_tokens`, or the chat-completions
-`prompt_tokens` / `completion_tokens`) multiplied by the model's per-token
-price. Prices are in USD per 1,000,000 tokens and can be overridden at runtime
-with --price-in / --price-out.
+(`usage.input_tokens` / `output_tokens`, plus cached input tokens from
+`usage.input_tokens_details.cached_tokens`; the chat-completions equivalents
+are `prompt_tokens` / `completion_tokens` / `prompt_tokens_details`) multiplied
+by the model's per-token price. Prices are USD per 1,000,000 tokens and can be
+overridden at runtime with --price-in / --price-out / --price-cached.
 
 For org-wide *billed* cost reconciliation, see org_costs.py, which queries the
 OpenAI Organization Costs API.
@@ -15,72 +16,92 @@ import json
 import time
 from os import path
 
-# USD per 1,000,000 tokens: (input, output).
-# These are NOT authoritative -- set the real numbers here or pass
-# --price-in / --price-out on the command line.
+# USD per 1,000,000 tokens: (input, output, cached_input).
+# cached_input is optional; if omitted, cached tokens are billed at the input
+# rate. Override at runtime with --price-in / --price-out / --price-cached.
 PRICING = {
-    'gpt-5.4-mini': (None, None),   # unknown to this script; supply prices
+    'gpt-5.4-mini': (0.75, 4.50, 0.075),
 }
 
 
+def _get(obj, *names):
+    for n in names:
+        v = getattr(obj, n, None)
+        if v is None and isinstance(obj, dict):
+            v = obj.get(n)
+        if v is not None:
+            return v
+    return None
+
+
 def normalize_usage(resp):
-    """Extract (input, output, total) token counts from a Responses or
-    ChatCompletions response (object or dict)."""
+    """Extract token counts from a Responses or ChatCompletions response.
+
+    Returns input_tokens (total prompt tokens, including cached),
+    cached_input_tokens, output_tokens, total_tokens."""
     usage = getattr(resp, 'usage', None)
     if usage is None and isinstance(resp, dict):
         usage = resp.get('usage')
     if usage is None:
-        return {'input_tokens': 0, 'output_tokens': 0, 'total_tokens': 0}
+        return {'input_tokens': 0, 'cached_input_tokens': 0,
+                'output_tokens': 0, 'total_tokens': 0}
 
-    def get(obj, *names):
-        for n in names:
-            v = getattr(obj, n, None)
-            if v is None and isinstance(obj, dict):
-                v = obj.get(n)
-            if v is not None:
-                return v
-        return 0
+    inp = _get(usage, 'input_tokens', 'prompt_tokens') or 0
+    out = _get(usage, 'output_tokens', 'completion_tokens') or 0
+    tot = _get(usage, 'total_tokens') or (inp + out)
 
-    inp = get(usage, 'input_tokens', 'prompt_tokens')
-    out = get(usage, 'output_tokens', 'completion_tokens')
-    tot = get(usage, 'total_tokens') or (inp + out)
-    return {'input_tokens': inp, 'output_tokens': out, 'total_tokens': tot}
+    cached = 0
+    details = _get(usage, 'input_tokens_details', 'prompt_tokens_details')
+    if details is not None:
+        cached = _get(details, 'cached_tokens') or 0
+
+    return {'input_tokens': inp, 'cached_input_tokens': cached,
+            'output_tokens': out, 'total_tokens': tot}
 
 
-def resolve_price(model, price_in, price_out):
+def resolve_price(model, price_in, price_out, price_cached):
     """Fill in missing prices from the PRICING table if available."""
     table = PRICING.get(model)
-    if price_in is None and table:
-        price_in = table[0]
-    if price_out is None and table:
-        price_out = table[1]
-    return price_in, price_out
+    if table:
+        if price_in is None:
+            price_in = table[0]
+        if price_out is None:
+            price_out = table[1]
+        if price_cached is None and len(table) > 2:
+            price_cached = table[2]
+    return price_in, price_out, price_cached
 
 
-def compute_cost(usage, price_in, price_out):
+def compute_cost(usage, price_in, price_out, price_cached=None):
     if price_in is None or price_out is None:
         return None
-    return (usage['input_tokens'] / 1e6) * price_in + \
+    cached = usage.get('cached_input_tokens', 0) or 0
+    uncached = max(usage['input_tokens'] - cached, 0)
+    cached_rate = price_in if price_cached is None else price_cached
+    return (uncached / 1e6) * price_in + \
+           (cached / 1e6) * cached_rate + \
            (usage['output_tokens'] / 1e6) * price_out
 
 
 class CostTracker:
     """Accumulates per-call cost, persists to JSON (resumable across runs)."""
 
-    def __init__(self, model, price_in, price_out, save_path, logger=print):
+    def __init__(self, model, price_in, price_out, save_path,
+                 price_cached=None, logger=print):
         self.model = model
-        self.price_in, self.price_out = resolve_price(model, price_in, price_out)
+        self.price_in, self.price_out, self.price_cached = resolve_price(
+            model, price_in, price_out, price_cached)
         self.save_path = save_path
         self.log = logger
         self.calls = []
-        self.totals = {'input_tokens': 0, 'output_tokens': 0,
-                       'total_tokens': 0, 'cost_usd': 0.0}
+        self.totals = {'input_tokens': 0, 'cached_input_tokens': 0,
+                       'output_tokens': 0, 'total_tokens': 0, 'cost_usd': 0.0}
         if save_path and path.exists(save_path):
             try:
                 with open(save_path) as f:
                     data = json.load(f)
                 self.calls = data.get('calls', [])
-                self.totals = data.get('totals', self.totals)
+                self.totals = {**self.totals, **data.get('totals', {})}
             except (ValueError, OSError):
                 pass
         if self.price_in is None or self.price_out is None:
@@ -89,23 +110,23 @@ class CostTracker:
                      f'Recording token counts only.')
 
     def add(self, bug_id, usage):
-        cost = compute_cost(usage, self.price_in, self.price_out)
+        cost = compute_cost(usage, self.price_in, self.price_out, self.price_cached)
         if cost is not None:
             cost = round(cost, 6)
         self.calls.append({'bug_id': bug_id, **usage, 'cost_usd': cost,
                            'at': time.strftime('%Y-%m-%dT%H:%M:%S')})
-        self.totals['input_tokens'] += usage['input_tokens']
-        self.totals['output_tokens'] += usage['output_tokens']
-        self.totals['total_tokens'] += usage['total_tokens']
+        for k in ('input_tokens', 'cached_input_tokens', 'output_tokens', 'total_tokens'):
+            self.totals[k] += usage.get(k, 0)
         if cost is not None:
             self.totals['cost_usd'] = round(self.totals['cost_usd'] + cost, 6)
 
         call_str = f'${cost:.4f}' if cost is not None else 'n/a'
         cum_str = (f"${self.totals['cost_usd']:.4f}"
                    if self.price_in is not None else 'n/a')
+        cached = usage.get('cached_input_tokens', 0)
         self.log(f"    [cost] {bug_id}: in={usage['input_tokens']} "
-                 f"out={usage['output_tokens']} call={call_str} "
-                 f"cumulative={cum_str} ({len(self.calls)} calls)")
+                 f"(cached={cached}) out={usage['output_tokens']} "
+                 f"call={call_str} cumulative={cum_str} ({len(self.calls)} calls)")
         self.save()
         return cost
 
@@ -116,7 +137,9 @@ class CostTracker:
         with open(self.save_path, 'w') as f:
             json.dump({
                 'model': self.model,
-                'price_per_1m_usd': {'input': self.price_in, 'output': self.price_out},
+                'price_per_1m_usd': {'input': self.price_in,
+                                     'output': self.price_out,
+                                     'cached_input': self.price_cached},
                 'totals': self.totals,
                 'calls': self.calls,
             }, f, indent=2)

--- a/simple_d4j_pipeline/cost.py
+++ b/simple_d4j_pipeline/cost.py
@@ -1,0 +1,122 @@
+"""Per-call and cumulative OpenAI cost tracking for the generation pipeline.
+
+Cost is computed from the token usage returned on each API response
+(`usage.input_tokens` / `output_tokens`, or the chat-completions
+`prompt_tokens` / `completion_tokens`) multiplied by the model's per-token
+price. Prices are in USD per 1,000,000 tokens and can be overridden at runtime
+with --price-in / --price-out.
+
+For org-wide *billed* cost reconciliation, see org_costs.py, which queries the
+OpenAI Organization Costs API.
+"""
+
+import os
+import json
+import time
+from os import path
+
+# USD per 1,000,000 tokens: (input, output).
+# These are NOT authoritative -- set the real numbers here or pass
+# --price-in / --price-out on the command line.
+PRICING = {
+    'gpt-5.4-mini': (None, None),   # unknown to this script; supply prices
+}
+
+
+def normalize_usage(resp):
+    """Extract (input, output, total) token counts from a Responses or
+    ChatCompletions response (object or dict)."""
+    usage = getattr(resp, 'usage', None)
+    if usage is None and isinstance(resp, dict):
+        usage = resp.get('usage')
+    if usage is None:
+        return {'input_tokens': 0, 'output_tokens': 0, 'total_tokens': 0}
+
+    def get(obj, *names):
+        for n in names:
+            v = getattr(obj, n, None)
+            if v is None and isinstance(obj, dict):
+                v = obj.get(n)
+            if v is not None:
+                return v
+        return 0
+
+    inp = get(usage, 'input_tokens', 'prompt_tokens')
+    out = get(usage, 'output_tokens', 'completion_tokens')
+    tot = get(usage, 'total_tokens') or (inp + out)
+    return {'input_tokens': inp, 'output_tokens': out, 'total_tokens': tot}
+
+
+def resolve_price(model, price_in, price_out):
+    """Fill in missing prices from the PRICING table if available."""
+    table = PRICING.get(model)
+    if price_in is None and table:
+        price_in = table[0]
+    if price_out is None and table:
+        price_out = table[1]
+    return price_in, price_out
+
+
+def compute_cost(usage, price_in, price_out):
+    if price_in is None or price_out is None:
+        return None
+    return (usage['input_tokens'] / 1e6) * price_in + \
+           (usage['output_tokens'] / 1e6) * price_out
+
+
+class CostTracker:
+    """Accumulates per-call cost, persists to JSON (resumable across runs)."""
+
+    def __init__(self, model, price_in, price_out, save_path, logger=print):
+        self.model = model
+        self.price_in, self.price_out = resolve_price(model, price_in, price_out)
+        self.save_path = save_path
+        self.log = logger
+        self.calls = []
+        self.totals = {'input_tokens': 0, 'output_tokens': 0,
+                       'total_tokens': 0, 'cost_usd': 0.0}
+        if save_path and path.exists(save_path):
+            try:
+                with open(save_path) as f:
+                    data = json.load(f)
+                self.calls = data.get('calls', [])
+                self.totals = data.get('totals', self.totals)
+            except (ValueError, OSError):
+                pass
+        if self.price_in is None or self.price_out is None:
+            self.log(f'    [cost] WARNING: no pricing for {model}; pass '
+                     f'--price-in/--price-out (USD per 1M tokens). '
+                     f'Recording token counts only.')
+
+    def add(self, bug_id, usage):
+        cost = compute_cost(usage, self.price_in, self.price_out)
+        if cost is not None:
+            cost = round(cost, 6)
+        self.calls.append({'bug_id': bug_id, **usage, 'cost_usd': cost,
+                           'at': time.strftime('%Y-%m-%dT%H:%M:%S')})
+        self.totals['input_tokens'] += usage['input_tokens']
+        self.totals['output_tokens'] += usage['output_tokens']
+        self.totals['total_tokens'] += usage['total_tokens']
+        if cost is not None:
+            self.totals['cost_usd'] = round(self.totals['cost_usd'] + cost, 6)
+
+        call_str = f'${cost:.4f}' if cost is not None else 'n/a'
+        cum_str = (f"${self.totals['cost_usd']:.4f}"
+                   if self.price_in is not None else 'n/a')
+        self.log(f"    [cost] {bug_id}: in={usage['input_tokens']} "
+                 f"out={usage['output_tokens']} call={call_str} "
+                 f"cumulative={cum_str} ({len(self.calls)} calls)")
+        self.save()
+        return cost
+
+    def save(self):
+        if not self.save_path:
+            return
+        os.makedirs(path.dirname(self.save_path) or '.', exist_ok=True)
+        with open(self.save_path, 'w') as f:
+            json.dump({
+                'model': self.model,
+                'price_per_1m_usd': {'input': self.price_in, 'output': self.price_out},
+                'totals': self.totals,
+                'calls': self.calls,
+            }, f, indent=2)

--- a/simple_d4j_pipeline/cost.py
+++ b/simple_d4j_pipeline/cost.py
@@ -20,7 +20,13 @@ from os import path
 # cached_input is optional; if omitted, cached tokens are billed at the input
 # rate. Override at runtime with --price-in / --price-out / --price-cached.
 PRICING = {
-    'gpt-5.4-mini': (0.75, 4.50, 0.075),
+    'gpt-5.5':       (5.00, 30.00, 0.50),
+    'gpt-5.4':       (2.50, 15.00, 0.25),
+    'gpt-5.4-mini':  (0.75,  4.50, 0.075),
+    'gpt-5.2':       (1.75, 14.00, 0.175),
+    'gpt-5.1':       (1.25, 10.00, 0.125),
+    'gpt-5':         (1.25, 10.00, 0.125),
+    'gpt-5-mini':    (0.25,  2.00, 0.025),
 }
 
 

--- a/simple_d4j_pipeline/csv_data.py
+++ b/simple_d4j_pipeline/csv_data.py
@@ -1,0 +1,71 @@
+"""Read the manual-evaluation CSV and expose the bugs with incorrect LLM patches.
+
+We only look at the two "-ori" model columns the task cares about. A patch
+counts as a usable incorrect patch when its Eval cell == 'incorrect' AND the
+patch text is non-empty.
+"""
+
+import csv
+
+# (llm_key, patch_column_index, eval_column_index) for the two -ori models.
+LLM_COLUMNS = [
+    ('claude-sonnet-4', 4, 5),
+    ('gemini-3-pro-preview', 10, 11),
+]
+
+DEV_PATCH_COL = 2
+BUG_ID_COL = 1
+
+
+def split_bug(bug_id):
+    """'Chart-16' -> ('Chart', '16'); 'JacksonDatabind-1' -> ('JacksonDatabind', '1')."""
+    pid, num = bug_id.rsplit('-', 1)
+    return pid, num
+
+
+def repo_buggy(pid, bug):
+    return f'{pid}_{bug}b'
+
+
+def repo_fixed(pid, bug):
+    return f'{pid}_{bug}f'
+
+
+def repo_llm(pid, bug, llm_key):
+    return f'{pid}_{bug}_{llm_key}'
+
+
+def load_incorrect(csv_path):
+    """Return a dict keyed by bug_id for every bug with >=1 usable incorrect
+    patch:
+
+        {
+          'Chart-16': {
+             'pid': 'Chart', 'bug': '16',
+             'dev_patch': '<diff>',
+             'incorrect': [('claude-sonnet-4', '<diff>'), ...],
+          }, ...
+        }
+    """
+    out = {}
+    with open(csv_path, newline='') as f:
+        rows = list(csv.reader(f))
+    for row in rows[1:]:
+        if len(row) <= BUG_ID_COL or not row[BUG_ID_COL]:
+            continue
+        bug_id = row[BUG_ID_COL]
+        incorrect = []
+        for key, patch_idx, eval_idx in LLM_COLUMNS:
+            if len(row) <= eval_idx:
+                continue
+            if row[eval_idx].strip().lower() == 'incorrect' and row[patch_idx].strip():
+                incorrect.append((key, row[patch_idx]))
+        if not incorrect:
+            continue
+        pid, bug = split_bug(bug_id)
+        out[bug_id] = {
+            'pid': pid, 'bug': bug,
+            'dev_patch': row[DEV_PATCH_COL],
+            'incorrect': incorrect,
+        }
+    return out

--- a/simple_d4j_pipeline/csv_data.py
+++ b/simple_d4j_pipeline/csv_data.py
@@ -1,16 +1,19 @@
 """Read the manual-evaluation CSV and expose the bugs with incorrect LLM patches.
 
-We only look at the two "-ori" model columns the task cares about. A patch
-counts as a usable incorrect patch when its Eval cell == 'incorrect' AND the
-patch text is non-empty.
+We look at both the "-ori" and "-norm" variants of each model. A patch counts
+as a usable incorrect patch when its Eval cell == 'incorrect' AND the patch
+text is non-empty. The llm_key matches the CSV column header, so each variant
+gets its own buggy_<llm> checkout.
 """
 
 import csv
 
-# (llm_key, patch_column_index, eval_column_index) for the two -ori models.
+# (llm_key, patch_column_index, eval_column_index) for each model/variant.
 LLM_COLUMNS = [
-    ('claude-sonnet-4', 4, 5),
-    ('gemini-3-pro-preview', 10, 11),
+    ('claude-sonnet-4-ori', 4, 5),
+    ('claude-sonnet-4-norm', 7, 8),
+    ('gemini-3-pro-preview-ori', 10, 11),
+    ('gemini-3-pro-preview-norm', 13, 14),
 ]
 
 DEV_PATCH_COL = 2

--- a/simple_d4j_pipeline/csv_data.py
+++ b/simple_d4j_pipeline/csv_data.py
@@ -35,6 +35,19 @@ def repo_llm(pid, bug, llm_key):
     return f'{pid}_{bug}_{llm_key}'
 
 
+def select(bugs, project=None, bug=None):
+    """Filter a load_incorrect() dict by project and/or bug id, returning a
+    sorted list of (bug_id, info). `bug` is the numeric d4j id (e.g. '16')."""
+    out = []
+    for bug_id, info in sorted(bugs.items()):
+        if project and info['pid'] != project:
+            continue
+        if bug and info['bug'] != str(bug):
+            continue
+        out.append((bug_id, info))
+    return out
+
+
 def load_incorrect(csv_path):
     """Return a dict keyed by bug_id for every bug with >=1 usable incorrect
     patch:

--- a/simple_d4j_pipeline/d4j_tests.py
+++ b/simple_d4j_pipeline/d4j_tests.py
@@ -1,0 +1,48 @@
+"""Extract the bug-triggering developer tests from a Defects4J checkout.
+
+`defects4j export -p tests.trigger` lists the triggering tests of the currently
+checked-out bug as `Class::method` lines. We read the source of each such
+method so it can be embedded in the LLM prompt.
+"""
+
+import codecs
+import subprocess as sp
+from os import path
+
+from java_utils import extract_method_by_name as extract_method
+
+
+def trigger_tests(repo):
+    """Return the list of triggering 'Class::method' ids for the checkout."""
+    proc = sp.run(['defects4j', 'export', '-p', 'tests.trigger'],
+                  capture_output=True, cwd=repo)
+    out = proc.stdout.decode('utf-8', 'ignore').strip()
+    ids = []
+    for line in out.replace(';', '\n').split('\n'):
+        line = line.strip()
+        if '::' in line:
+            ids.append(line)
+    return ids
+
+
+def _export_dir(repo, prop):
+    proc = sp.run(['defects4j', 'export', '-p', prop], capture_output=True, cwd=repo)
+    return proc.stdout.decode('utf-8', 'ignore').strip().rstrip('/') + '/'
+
+
+def collect_trigger_sources(repo):
+    """Return concatenated source of all triggering test methods in the checkout."""
+    test_dir = _export_dir(repo, 'dir.src.tests')
+    blocks = []
+    for tid in trigger_tests(repo):
+        cls, _, method = tid.partition('::')
+        jfile = path.join(repo, test_dir, cls.replace('.', '/') + '.java')
+        if not path.isfile(jfile):
+            blocks.append(f'// {tid} (source file not found)')
+            continue
+        with codecs.open(jfile, 'r', encoding='utf-8', errors='ignore') as f:
+            content = f.read()
+        src = extract_method(content, method)
+        blocks.append(f'// {tid}\n{src}' if src
+                      else f'// {tid} (method body not found)')
+    return '\n\n'.join(blocks)

--- a/simple_d4j_pipeline/eval_augmented.py
+++ b/simple_d4j_pipeline/eval_augmented.py
@@ -1,0 +1,126 @@
+"""Evaluate augmented tests against buggy, fixed, and every buggy_<llm> variant.
+
+An augmented test is "correctly augmented" when it
+  - PASSES on fixed,
+  - FAILS on buggy,
+  - FAILS on every buggy_<llm> variant of that bug (>=1 variant required).
+
+Reuses the inject/compile/run machinery from run_pipeline.py.
+
+Usage:
+    python eval_augmented.py --csv eval.csv --repos-dir ./repos \
+        --tests-dir ./aug_tests --out aug_results.json
+"""
+
+import json
+import argparse
+from os import path
+
+import csv_data
+import run_pipeline as rp
+
+
+def classify(info):
+    """Map a run_one result to pass / fail / compile_error / error."""
+    if isinstance(info, str):
+        return 'error'
+    if info['compile_error']:
+        return 'compile_error'
+    if rp.fails_autogen(info):
+        return 'fail'
+    if info['runtime_error']:
+        return 'error'
+    return 'pass'
+
+
+def run_version(repo, gen_test):
+    src_dir = rp.export_dir(repo, 'dir.src.classes')
+    test_dir = rp.export_dir(repo, 'dir.src.tests')
+    try:
+        info = rp.run_one(repo, gen_test, src_dir, test_dir)
+    except Exception as e:
+        return 'error', {'error': repr(e)}
+    slim = {} if isinstance(info, str) else {
+        'compile_error': info['compile_error'],
+        'runtime_error': info['runtime_error'],
+        'failed_tests': info['failed_tests'],
+    }
+    return classify(info), slim
+
+
+def eval_bug(repos_dir, pid, bug, incorrect, gen_test):
+    versions = {}
+    detail = {}
+
+    buggy = path.join(repos_dir, csv_data.repo_buggy(pid, bug))
+    fixed = path.join(repos_dir, csv_data.repo_fixed(pid, bug))
+    if not path.isdir(buggy) or not path.isdir(fixed):
+        return None
+
+    versions['buggy'], detail['buggy'] = run_version(buggy, gen_test)
+    versions['fixed'], detail['fixed'] = run_version(fixed, gen_test)
+
+    llm_variants = []
+    for llm_key, _patch in incorrect:
+        vdir = path.join(repos_dir, csv_data.repo_llm(pid, bug, llm_key))
+        if not path.isdir(vdir):
+            continue
+        name = f'buggy_{llm_key}'
+        versions[name], detail[name] = run_version(vdir, gen_test)
+        llm_variants.append(name)
+
+    correctly_augmented = (
+        bool(llm_variants)
+        and versions['fixed'] == 'pass'
+        and versions['buggy'] == 'fail'
+        and all(versions[v] == 'fail' for v in llm_variants)
+    )
+    return {
+        'pid': pid, 'bug': bug,
+        'versions': versions,
+        'llm_variants': llm_variants,
+        'correctly_augmented': correctly_augmented,
+        'detail': detail,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--csv', required=True)
+    ap.add_argument('--repos-dir', required=True)
+    ap.add_argument('--tests-dir', required=True, help='dir with *_aug.txt')
+    ap.add_argument('--out', default='aug_results.json')
+    ap.add_argument('-p', '--project')
+    args = ap.parse_args()
+
+    bugs = csv_data.load_incorrect(args.csv)
+    results = {}
+    n_correct = 0
+    for bug_id, info in sorted(bugs.items()):
+        if args.project and info['pid'] != args.project:
+            continue
+        pid, bug = info['pid'], info['bug']
+        test_file = path.join(args.tests_dir, f'{pid}_{bug}_aug.txt')
+        if not path.isfile(test_file):
+            continue
+        with open(test_file) as f:
+            gen_test = rp.strip_fences(f.read())
+
+        print(f'=== {bug_id} ===', flush=True)
+        res = eval_bug(args.repos_dir, pid, bug, info['incorrect'], gen_test)
+        if res is None:
+            print(f'    [skip] missing buggy/fixed checkout')
+            continue
+        results[bug_id] = res
+        n_correct += int(res['correctly_augmented'])
+        print(f"    {res['versions']} -> correct={res['correctly_augmented']}",
+              flush=True)
+        with open(args.out, 'w') as f:
+            json.dump(results, f, indent=2)
+
+    print(f'[done] correctly augmented: {n_correct}/{len(results)} -> {args.out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/simple_d4j_pipeline/eval_augmented.py
+++ b/simple_d4j_pipeline/eval_augmented.py
@@ -17,6 +17,7 @@ import argparse
 from os import path
 
 import csv_data
+import plog
 import run_pipeline as rp
 
 
@@ -57,16 +58,26 @@ def eval_bug(repos_dir, pid, bug, incorrect, gen_test):
     if not path.isdir(buggy) or not path.isdir(fixed):
         return None
 
-    versions['buggy'], detail['buggy'] = run_version(buggy, gen_test)
-    versions['fixed'], detail['fixed'] = run_version(fixed, gen_test)
+    want = {'buggy': 'fail', 'fixed': 'pass'}
+
+    def run_and_log(name, repo):
+        status, det = run_version(repo, gen_test)
+        expect = want.get(name, 'fail')  # llm variants should fail
+        mark = 'OK ' if status == expect else '!! '
+        plog.log(f'    {mark}{name:<28} -> {status}  (want {expect})')
+        return status, det
+
+    versions['buggy'], detail['buggy'] = run_and_log('buggy', buggy)
+    versions['fixed'], detail['fixed'] = run_and_log('fixed', fixed)
 
     llm_variants = []
     for llm_key, _patch in incorrect:
         vdir = path.join(repos_dir, csv_data.repo_llm(pid, bug, llm_key))
         if not path.isdir(vdir):
+            plog.log(f'    -- buggy_{llm_key} (checkout missing, skipped)')
             continue
         name = f'buggy_{llm_key}'
-        versions[name], detail[name] = run_version(vdir, gen_test)
+        versions[name], detail[name] = run_and_log(name, vdir)
         llm_variants.append(name)
 
     correctly_augmented = (
@@ -95,31 +106,34 @@ def main():
     args = ap.parse_args()
 
     bugs = csv_data.load_incorrect(args.csv)
+    targets = [(b, i) for b, i in sorted(bugs.items())
+               if not args.project or i['pid'] == args.project]
+    targets = [(b, i) for b, i in targets
+               if path.isfile(path.join(args.tests_dir, f"{i['pid']}_{i['bug']}_aug.txt"))]
+    plog.log(f'evaluating {len(targets)} augmented test(s)')
+
     results = {}
     n_correct = 0
-    for bug_id, info in sorted(bugs.items()):
-        if args.project and info['pid'] != args.project:
-            continue
+    for idx, (bug_id, info) in enumerate(targets, 1):
         pid, bug = info['pid'], info['bug']
         test_file = path.join(args.tests_dir, f'{pid}_{bug}_aug.txt')
-        if not path.isfile(test_file):
-            continue
         with open(test_file) as f:
             gen_test = rp.strip_fences(f.read())
 
-        print(f'=== {bug_id} ===', flush=True)
+        plog.log(f'=== [eval {idx}/{len(targets)}] {bug_id} ===')
+        plog.block('augmented test method', gen_test)
         res = eval_bug(args.repos_dir, pid, bug, info['incorrect'], gen_test)
         if res is None:
-            print(f'    [skip] missing buggy/fixed checkout')
+            plog.log('    skip: missing buggy/fixed checkout')
             continue
         results[bug_id] = res
         n_correct += int(res['correctly_augmented'])
-        print(f"    {res['versions']} -> correct={res['correctly_augmented']}",
-              flush=True)
+        verdict = 'CORRECTLY AUGMENTED' if res['correctly_augmented'] else 'not distinguishing'
+        plog.log(f'    => {verdict}  ({n_correct} correct so far)')
         with open(args.out, 'w') as f:
             json.dump(results, f, indent=2)
 
-    print(f'[done] correctly augmented: {n_correct}/{len(results)} -> {args.out}')
+    plog.log(f'[done] correctly augmented: {n_correct}/{len(results)} -> {args.out}')
 
 
 if __name__ == '__main__':

--- a/simple_d4j_pipeline/eval_augmented.py
+++ b/simple_d4j_pipeline/eval_augmented.py
@@ -103,12 +103,11 @@ def main():
     ap.add_argument('--tests-dir', required=True, help='dir with *_aug.txt')
     ap.add_argument('--out', default='aug_results.json')
     ap.add_argument('-p', '--project')
+    ap.add_argument('-b', '--bug', help='restrict to one bug id (use with -p)')
     args = ap.parse_args()
 
     bugs = csv_data.load_incorrect(args.csv)
-    targets = [(b, i) for b, i in sorted(bugs.items())
-               if not args.project or i['pid'] == args.project]
-    targets = [(b, i) for b, i in targets
+    targets = [(b, i) for b, i in csv_data.select(bugs, args.project, args.bug)
                if path.isfile(path.join(args.tests_dir, f"{i['pid']}_{i['bug']}_aug.txt"))]
     plog.log(f'evaluating {len(targets)} augmented test(s)')
 

--- a/simple_d4j_pipeline/eval_augmented.py
+++ b/simple_d4j_pipeline/eval_augmented.py
@@ -100,14 +100,28 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('--csv', required=True)
     ap.add_argument('--repos-dir', required=True)
-    ap.add_argument('--tests-dir', required=True, help='dir with *_aug.txt')
-    ap.add_argument('--out', default='aug_results.json')
+    ap.add_argument('--tests-dir', help='dir with *_aug.txt '
+                    '(default <out-dir>/<model>/aug_tests when --out-dir given)')
+    ap.add_argument('--out-dir', help='per-model results root (matches gen/try_k); '
+                    'derives --tests-dir and --out from <out-dir>/<model>')
+    ap.add_argument('--model', default='gpt-5.4-mini',
+                    help='used only to locate the per-model folder under --out-dir')
+    ap.add_argument('--out', help='results JSON (default aug_results.json, or '
+                    '<out-dir>/<model>/aug_results.json)')
     ap.add_argument('-p', '--project')
     ap.add_argument('-b', '--bug', help='restrict to one bug id (use with -p)')
     ap.add_argument('--records-dir',
                     help='per-bug artifact dir to merge eval into '
                          '(default <tests-dir>/records)')
     args = ap.parse_args()
+
+    if args.out_dir:
+        base = path.join(args.out_dir, args.model)
+        args.tests_dir = args.tests_dir or path.join(base, 'aug_tests')
+        args.out = args.out or path.join(base, 'aug_results.json')
+    if not args.tests_dir:
+        ap.error('provide --tests-dir or --out-dir')
+    args.out = args.out or 'aug_results.json'
     records_dir = args.records_dir or path.join(args.tests_dir, 'records')
 
     bugs = csv_data.load_incorrect(args.csv)

--- a/simple_d4j_pipeline/eval_augmented.py
+++ b/simple_d4j_pipeline/eval_augmented.py
@@ -104,7 +104,11 @@ def main():
     ap.add_argument('--out', default='aug_results.json')
     ap.add_argument('-p', '--project')
     ap.add_argument('-b', '--bug', help='restrict to one bug id (use with -p)')
+    ap.add_argument('--records-dir',
+                    help='per-bug artifact dir to merge eval into '
+                         '(default <tests-dir>/records)')
     args = ap.parse_args()
+    records_dir = args.records_dir or path.join(args.tests_dir, 'records')
 
     bugs = csv_data.load_incorrect(args.csv)
     targets = [(b, i) for b, i in csv_data.select(bugs, args.project, args.bug)
@@ -129,6 +133,18 @@ def main():
         n_correct += int(res['correctly_augmented'])
         verdict = 'CORRECTLY AUGMENTED' if res['correctly_augmented'] else 'not distinguishing'
         plog.log(f'    => {verdict}  ({n_correct} correct so far)')
+
+        # Merge the eval result into the per-bug generation record if present.
+        rec_path = path.join(records_dir, f'{pid}_{bug}.json')
+        if path.isfile(rec_path):
+            try:
+                with open(rec_path) as f:
+                    rec = json.load(f)
+                rec['eval'] = res
+                with open(rec_path, 'w') as f:
+                    json.dump(rec, f, indent=2)
+            except (ValueError, OSError):
+                pass
         with open(args.out, 'w') as f:
             json.dump(results, f, indent=2)
 

--- a/simple_d4j_pipeline/gen_augmented.py
+++ b/simple_d4j_pipeline/gen_augmented.py
@@ -21,6 +21,7 @@ from os import path
 
 import csv_data
 import d4j_tests
+import plog
 from java_utils import matching_brace
 
 
@@ -144,38 +145,52 @@ def main():
 
     os.makedirs(args.tests_dir, exist_ok=True)
     bugs = csv_data.load_incorrect(args.csv)
+    targets = [(b, i) for b, i in sorted(bugs.items())
+               if not args.project or i['pid'] == args.project]
+    plog.log(f'generating augmented tests for {len(targets)} bug(s) '
+             f'with model={args.model}')
 
-    n_done = n_fail = 0
-    for bug_id, info in sorted(bugs.items()):
-        if args.project and info['pid'] != args.project:
-            continue
+    n_done = n_fail = n_skip = 0
+    for idx, (bug_id, info) in enumerate(targets, 1):
         pid, bug = info['pid'], info['bug']
+        models = ', '.join(k for k, _ in info['incorrect'])
+        plog.log(f'[gen {idx}/{len(targets)}] {bug_id}  incorrect_models=[{models}]')
+
         out_path = path.join(args.tests_dir, f'{pid}_{bug}_aug.txt')
         if path.exists(out_path) and not args.overwrite:
+            plog.log(f'    skip: {path.basename(out_path)} already exists')
+            n_skip += 1
             continue
 
         fixed = path.join(args.repos_dir, csv_data.repo_fixed(pid, bug))
         buggy = path.join(args.repos_dir, csv_data.repo_buggy(pid, bug))
         src_repo = fixed if path.isdir(fixed) else buggy
         if not path.isdir(src_repo):
-            print(f'[skip] {bug_id}: no checkout to read triggering tests from')
+            plog.log(f'    skip: no checkout to read triggering tests from')
+            n_skip += 1
             continue
+
         failing_tests = d4j_tests.collect_trigger_sources(src_repo)
+        n_trigger = failing_tests.count('//') if failing_tests else 0
+        plog.log(f'    triggering dev tests: ~{n_trigger} method(s), '
+                 f'{len(failing_tests)} chars  (from {path.basename(src_repo)})')
         prompt = build_prompt(info, failing_tests)
         if args.save_prompts:
             with open(path.join(args.tests_dir, f'{pid}_{bug}_prompt.txt'), 'w') as f:
                 f.write(prompt)
+        plog.log(f'    querying OpenAI ({len(prompt)} char prompt)...')
 
         try:
             reply = query_openai(prompt, args.model)
         except Exception as e:
-            print(f'[fail] {bug_id}: API error {e!r}')
+            plog.log(f'    FAIL: API error {e!r}')
             n_fail += 1
             continue
 
         method = extract_test_method(reply)
         if not method:
-            print(f'[fail] {bug_id}: could not parse a test method from reply')
+            plog.log(f'    FAIL: could not parse a test method from reply '
+                     f'(raw saved to {path.basename(out_path)}.raw)')
             with open(out_path + '.raw', 'w') as f:
                 f.write(reply)
             n_fail += 1
@@ -183,10 +198,11 @@ def main():
 
         with open(out_path, 'w') as f:
             f.write(method)
-        print(f'[ok]   {bug_id} -> {path.basename(out_path)}')
+        plog.block('generated test method', method)
+        plog.log(f'    saved -> {path.basename(out_path)}')
         n_done += 1
 
-    print(f'[done] generated={n_done} failed={n_fail}')
+    plog.log(f'[done] generated={n_done} failed={n_fail} skipped={n_skip}')
 
 
 if __name__ == '__main__':

--- a/simple_d4j_pipeline/gen_augmented.py
+++ b/simple_d4j_pipeline/gen_augmented.py
@@ -16,10 +16,13 @@ Usage:
 
 import os
 import re
+import json
+import time
 import argparse
 from os import path
 
 import csv_data
+import cost
 import d4j_tests
 import plog
 from java_utils import matching_brace
@@ -119,15 +122,16 @@ def extract_test_method(text):
 
 
 def query_openai(prompt, model):
+    """Return (reply_text, usage_dict)."""
     from openai import OpenAI
     client = OpenAI()
     try:
         resp = client.responses.create(model=model, input=prompt)
-        return resp.output_text
+        return resp.output_text, cost.normalize_usage(resp)
     except (AttributeError, TypeError):
         resp = client.chat.completions.create(
             model=model, messages=[{'role': 'user', 'content': prompt}])
-        return resp.choices[0].message.content
+        return resp.choices[0].message.content, cost.normalize_usage(resp)
 
 
 def main():
@@ -142,9 +146,23 @@ def main():
     ap.add_argument('--overwrite', action='store_true')
     ap.add_argument('--save-prompts', action='store_true',
                     help='also write the prompt to <tests-dir>/<bug>_prompt.txt')
+    ap.add_argument('--records-dir',
+                    help='dir for per-bug artifact JSON (default <tests-dir>/records)')
+    ap.add_argument('--cost-out',
+                    help='cumulative cost JSON (default <records-dir>/cost.json)')
+    ap.add_argument('--price-in', type=float,
+                    help='USD per 1M input tokens (overrides cost.PRICING)')
+    ap.add_argument('--price-out', type=float,
+                    help='USD per 1M output tokens (overrides cost.PRICING)')
     args = ap.parse_args()
 
     os.makedirs(args.tests_dir, exist_ok=True)
+    records_dir = args.records_dir or path.join(args.tests_dir, 'records')
+    os.makedirs(records_dir, exist_ok=True)
+    cost_out = args.cost_out or path.join(records_dir, 'cost.json')
+    tracker = cost.CostTracker(args.model, args.price_in, args.price_out,
+                               cost_out, logger=plog.log)
+
     bugs = csv_data.load_incorrect(args.csv)
     targets = csv_data.select(bugs, args.project, args.bug)
     plog.log(f'generating augmented tests for {len(targets)} bug(s) '
@@ -181,13 +199,34 @@ def main():
         plog.log(f'    querying OpenAI ({len(prompt)} char prompt)...')
 
         try:
-            reply = query_openai(prompt, args.model)
+            reply, usage = query_openai(prompt, args.model)
         except Exception as e:
             plog.log(f'    FAIL: API error {e!r}')
             n_fail += 1
             continue
 
+        call_cost = tracker.add(bug_id, usage)
         method = extract_test_method(reply)
+
+        # Persist all generation artifacts for this bug.
+        record = {
+            'bug_id': bug_id, 'pid': pid, 'bug': bug, 'model': args.model,
+            'incorrect_models': [k for k, _ in info['incorrect']],
+            'inputs': {
+                'dev_patch': info['dev_patch'],
+                'llm_patches': [{'model': k, 'patch': p} for k, p in info['incorrect']],
+                'failing_tests': failing_tests,
+            },
+            'prompt': prompt,
+            'raw_reply': reply,
+            'generated_method': method,
+            'usage': usage,
+            'cost_usd': call_cost,
+            'generated_at': time.strftime('%Y-%m-%dT%H:%M:%S'),
+        }
+        with open(path.join(records_dir, f'{pid}_{bug}.json'), 'w') as f:
+            json.dump(record, f, indent=2)
+
         if not method:
             plog.log(f'    FAIL: could not parse a test method from reply '
                      f'(raw saved to {path.basename(out_path)}.raw)')
@@ -199,10 +238,13 @@ def main():
         with open(out_path, 'w') as f:
             f.write(method)
         plog.block('generated test method', method)
-        plog.log(f'    saved -> {path.basename(out_path)}')
+        plog.log(f'    saved -> {path.basename(out_path)}  (record: {pid}_{bug}.json)')
         n_done += 1
 
+    t = tracker.totals
     plog.log(f'[done] generated={n_done} failed={n_fail} skipped={n_skip}')
+    plog.log(f'[cost] cumulative: {t["total_tokens"]} tokens, '
+             f'${t["cost_usd"]:.4f} over {len(tracker.calls)} calls -> {cost_out}')
 
 
 if __name__ == '__main__':

--- a/simple_d4j_pipeline/gen_augmented.py
+++ b/simple_d4j_pipeline/gen_augmented.py
@@ -139,7 +139,10 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('--csv', required=True)
     ap.add_argument('--repos-dir', required=True)
-    ap.add_argument('--tests-dir', required=True, help='output dir for *_aug.txt')
+    ap.add_argument('--tests-dir', help='output dir for *_aug.txt '
+                    '(default <out-dir>/<model>/aug_tests when --out-dir given)')
+    ap.add_argument('--out-dir', help='per-model results root; tests go to '
+                    '<out-dir>/<model>/aug_tests')
     ap.add_argument('--model', default='gpt-5.4-mini')
     ap.add_argument('-p', '--project', help='restrict to one project')
     ap.add_argument('-b', '--bug', help='restrict to one bug id (use with -p)')
@@ -157,6 +160,11 @@ def main():
     ap.add_argument('--price-cached', type=float,
                     help='USD per 1M cached input tokens (overrides cost.PRICING)')
     args = ap.parse_args()
+
+    if not args.tests_dir:
+        if not args.out_dir:
+            ap.error('provide --tests-dir or --out-dir')
+        args.tests_dir = path.join(args.out_dir, args.model, 'aug_tests')
 
     os.makedirs(args.tests_dir, exist_ok=True)
     records_dir = args.records_dir or path.join(args.tests_dir, 'records')

--- a/simple_d4j_pipeline/gen_augmented.py
+++ b/simple_d4j_pipeline/gen_augmented.py
@@ -1,0 +1,193 @@
+"""Generate an augmented regression test per bug via the OpenAI API.
+
+For each bug with >=1 incorrect LLM patch we build the task prompt from:
+  - the correct developer patch (CSV),
+  - every incorrect LLM patch (CSV),
+  - the bug's triggering developer tests (read from the checkout),
+query the model, parse out a single test method, and write it to
+<tests-dir>/<pid>_<bug>_aug.txt for the eval step.
+
+Needs OPENAI_API_KEY in the environment and the `openai` package.
+
+Usage:
+    python gen_augmented.py --csv eval.csv --repos-dir ./repos \
+        --tests-dir ./aug_tests --model gpt-5.4-mini
+"""
+
+import os
+import re
+import argparse
+from os import path
+
+import csv_data
+import d4j_tests
+from java_utils import matching_brace
+
+
+PROMPT_TEMPLATE = """\
+Projects:
+
+- `buggy`: original buggy project
+- `fixed`: project patched with the correct developer fix
+- `buggy_<llm>`: project patched with an incorrect LLM-generated patch
+
+Goal:
+Write an augmented regression test that:
+
+1. PASSES on `fixed`
+2. FAILS on `buggy`
+3. FAILS on `buggy_<llm>`
+
+Inputs:
+
+Correct Developer Patch:
+```diff
+{{correct_developer_patch}}
+```
+
+Diff of LLM-generated Patch:
+
+```diff
+{{llm_generated_patch_diff}}
+```
+
+Relevant Failing Developer Tests:
+
+```java
+{{relevant_failing_dev_tests}}
+```
+
+Task:
+Infer the behavioral difference between the correct developer patch and the incorrect LLM patch, then write a NEW augmented test that exercises behavior fixed only by the developer patch.
+
+Guidelines:
+
+* Do NOT duplicate the provided failing tests.
+* Target the exact semantic behavior fixed by the developer patch.
+* Prefer a minimal deterministic test.
+* Use the project's existing test style and APIs.
+* The test must pass on `fixed`.
+* The test must fail on both `buggy` and `buggy_<llm>`.
+* Output ONLY the complete test method.
+"""
+
+
+def build_prompt(info, failing_tests):
+    llm_blob = '\n\n'.join(
+        f'// ---- incorrect patch from {key} ----\n{patch}'
+        for key, patch in info['incorrect'])
+    return (PROMPT_TEMPLATE
+            .replace('{{correct_developer_patch}}', info['dev_patch'].strip())
+            .replace('{{llm_generated_patch_diff}}', llm_blob.strip())
+            .replace('{{relevant_failing_dev_tests}}', failing_tests.strip()))
+
+
+def strip_fences(text):
+    text = text.strip()
+    if text.startswith('```'):
+        text = text.split('\n', 1)[1] if '\n' in text else ''
+    if text.rstrip().endswith('```'):
+        text = text.rstrip()[:-3]
+    return text.strip()
+
+
+def extract_test_method(text):
+    """Pull a single Java test method out of the model's reply.
+
+    Handles fenced output, surrounding prose, or a whole class wrapper.
+    Returns the method source, or None if no method could be located.
+    """
+    text = strip_fences(text)
+    m = re.search(r'\bvoid\s+\w+\s*\(', text)
+    if not m:
+        return None
+    # Walk backwards over modifiers/annotations to capture the full signature.
+    line_start = text.rfind('\n', 0, m.start()) + 1
+    sig_start = line_start
+    prefix_lines = text[:line_start].rstrip().split('\n')
+    while prefix_lines and prefix_lines[-1].lstrip().startswith('@'):
+        dropped = prefix_lines.pop()
+        sig_start = text.rfind(dropped, 0, sig_start)
+    brace = text.find('{', m.end() - 1)
+    if brace == -1:
+        return None
+    end = matching_brace(text, brace)
+    if end == -1:
+        return None
+    return text[sig_start:end + 1].strip()
+
+
+def query_openai(prompt, model):
+    from openai import OpenAI
+    client = OpenAI()
+    try:
+        resp = client.responses.create(model=model, input=prompt)
+        return resp.output_text
+    except (AttributeError, TypeError):
+        resp = client.chat.completions.create(
+            model=model, messages=[{'role': 'user', 'content': prompt}])
+        return resp.choices[0].message.content
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--csv', required=True)
+    ap.add_argument('--repos-dir', required=True)
+    ap.add_argument('--tests-dir', required=True, help='output dir for *_aug.txt')
+    ap.add_argument('--model', default='gpt-5.4-mini')
+    ap.add_argument('-p', '--project', help='restrict to one project')
+    ap.add_argument('--overwrite', action='store_true')
+    ap.add_argument('--save-prompts', action='store_true',
+                    help='also write the prompt to <tests-dir>/<bug>_prompt.txt')
+    args = ap.parse_args()
+
+    os.makedirs(args.tests_dir, exist_ok=True)
+    bugs = csv_data.load_incorrect(args.csv)
+
+    n_done = n_fail = 0
+    for bug_id, info in sorted(bugs.items()):
+        if args.project and info['pid'] != args.project:
+            continue
+        pid, bug = info['pid'], info['bug']
+        out_path = path.join(args.tests_dir, f'{pid}_{bug}_aug.txt')
+        if path.exists(out_path) and not args.overwrite:
+            continue
+
+        fixed = path.join(args.repos_dir, csv_data.repo_fixed(pid, bug))
+        buggy = path.join(args.repos_dir, csv_data.repo_buggy(pid, bug))
+        src_repo = fixed if path.isdir(fixed) else buggy
+        if not path.isdir(src_repo):
+            print(f'[skip] {bug_id}: no checkout to read triggering tests from')
+            continue
+        failing_tests = d4j_tests.collect_trigger_sources(src_repo)
+        prompt = build_prompt(info, failing_tests)
+        if args.save_prompts:
+            with open(path.join(args.tests_dir, f'{pid}_{bug}_prompt.txt'), 'w') as f:
+                f.write(prompt)
+
+        try:
+            reply = query_openai(prompt, args.model)
+        except Exception as e:
+            print(f'[fail] {bug_id}: API error {e!r}')
+            n_fail += 1
+            continue
+
+        method = extract_test_method(reply)
+        if not method:
+            print(f'[fail] {bug_id}: could not parse a test method from reply')
+            with open(out_path + '.raw', 'w') as f:
+                f.write(reply)
+            n_fail += 1
+            continue
+
+        with open(out_path, 'w') as f:
+            f.write(method)
+        print(f'[ok]   {bug_id} -> {path.basename(out_path)}')
+        n_done += 1
+
+    print(f'[done] generated={n_done} failed={n_fail}')
+
+
+if __name__ == '__main__':
+    main()

--- a/simple_d4j_pipeline/gen_augmented.py
+++ b/simple_d4j_pipeline/gen_augmented.py
@@ -138,6 +138,7 @@ def main():
     ap.add_argument('--tests-dir', required=True, help='output dir for *_aug.txt')
     ap.add_argument('--model', default='gpt-5.4-mini')
     ap.add_argument('-p', '--project', help='restrict to one project')
+    ap.add_argument('-b', '--bug', help='restrict to one bug id (use with -p)')
     ap.add_argument('--overwrite', action='store_true')
     ap.add_argument('--save-prompts', action='store_true',
                     help='also write the prompt to <tests-dir>/<bug>_prompt.txt')
@@ -145,8 +146,7 @@ def main():
 
     os.makedirs(args.tests_dir, exist_ok=True)
     bugs = csv_data.load_incorrect(args.csv)
-    targets = [(b, i) for b, i in sorted(bugs.items())
-               if not args.project or i['pid'] == args.project]
+    targets = csv_data.select(bugs, args.project, args.bug)
     plog.log(f'generating augmented tests for {len(targets)} bug(s) '
              f'with model={args.model}')
 

--- a/simple_d4j_pipeline/gen_augmented.py
+++ b/simple_d4j_pipeline/gen_augmented.py
@@ -154,6 +154,8 @@ def main():
                     help='USD per 1M input tokens (overrides cost.PRICING)')
     ap.add_argument('--price-out', type=float,
                     help='USD per 1M output tokens (overrides cost.PRICING)')
+    ap.add_argument('--price-cached', type=float,
+                    help='USD per 1M cached input tokens (overrides cost.PRICING)')
     args = ap.parse_args()
 
     os.makedirs(args.tests_dir, exist_ok=True)
@@ -161,7 +163,8 @@ def main():
     os.makedirs(records_dir, exist_ok=True)
     cost_out = args.cost_out or path.join(records_dir, 'cost.json')
     tracker = cost.CostTracker(args.model, args.price_in, args.price_out,
-                               cost_out, logger=plog.log)
+                               cost_out, price_cached=args.price_cached,
+                               logger=plog.log)
 
     bugs = csv_data.load_incorrect(args.csv)
     targets = csv_data.select(bugs, args.project, args.bug)

--- a/simple_d4j_pipeline/import_checkouts.sh
+++ b/simple_d4j_pipeline/import_checkouts.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Import pre-existing buggy/ and fixed/ checkouts into the repos/ layout the
+# pipeline expects, instead of running `defects4j checkout`.
+#
+# Source layout (one directory per bug, e.g. the parent of these scripts'
+# workspace, matching /data/d4j_subjects/d4j_bugs):
+#   SRC_DIR/<Project>-<bug>/buggy     a Defects4J working directory
+#   SRC_DIR/<Project>-<bug>/fixed
+# Produces:
+#   REPOS_DIR/<Project>_<bug>b
+#   REPOS_DIR/<Project>_<bug>f
+#
+# The same SRC_DIR is what you pass to prepare_patched.py as --solutions-dir
+# (the LLM solution dirs <Project>-<bug>/source_ori-* and source_patched_rst-*
+# live alongside buggy/ and fixed/).
+#
+# Usage:
+#   bash import_checkouts.sh <SRC_DIR> [REPOS_DIR] [FILTER ...]
+# FILTER matches a project (e.g. Jsoup) or a full bug id (e.g. Chart-16).
+#
+# Examples:
+#   bash import_checkouts.sh .. ./repos
+#   bash import_checkouts.sh /home/secollab ./repos Jsoup Chart-16
+
+set -u
+
+SRC_DIR="${1:?usage: import_checkouts.sh <SRC_DIR> [REPOS_DIR] [FILTER ...]}"
+shift
+REPOS_DIR="${1:-$(pwd)/repos}"
+[ $# -gt 0 ] && shift || true
+FILTER="$*"
+
+matches() {   # $1 = bug name like Chart-16 ; uses global FILTER
+    local name="$1" pid="${1%-*}" tok
+    [ -z "$FILTER" ] && return 0
+    for tok in $FILTER; do
+        [ "$tok" = "$name" ] && return 0
+        [ "$tok" = "$pid" ] && return 0
+    done
+    return 1
+}
+
+mkdir -p "$REPOS_DIR"
+imported=0 skipped=0 missing=0 warned=0
+for bugdir in "$SRC_DIR"/*-*/; do
+    [ -d "$bugdir" ] || continue
+    name="$(basename "$bugdir")"
+    pid="${name%-*}"
+    num="${name##*-}"
+    [[ "$num" =~ ^[0-9]+$ ]] || continue
+    matches "$name" || continue
+
+    for pair in buggy:b fixed:f; do
+        sub="${pair%%:*}"
+        suf="${pair##*:}"
+        src="${bugdir}${sub}"
+        dest="$REPOS_DIR/${pid}_${num}${suf}"
+        if [ ! -d "$src" ]; then
+            echo "[miss] $name: no $sub/"
+            missing=$((missing + 1))
+            continue
+        fi
+        if [ -d "$dest" ]; then
+            skipped=$((skipped + 1))
+            continue
+        fi
+        if [ ! -f "$src/.defects4j.config" ]; then
+            echo "[warn] $src has no .defects4j.config (defects4j commands may fail)"
+            warned=$((warned + 1))
+        fi
+        cp -a "$src" "$dest"
+        echo "[ok]   $name/$sub -> ${pid}_${num}${suf}"
+        imported=$((imported + 1))
+    done
+done
+echo "[done] imported=$imported skipped=$skipped missing=$missing warned=$warned -> $REPOS_DIR"

--- a/simple_d4j_pipeline/injector.py
+++ b/simple_d4j_pipeline/injector.py
@@ -1,0 +1,303 @@
+"""Inject a bare LLM-generated JUnit test method into a Defects4J checkout.
+
+Ported and simplified from libro's `common.py`. Given a single generated test
+*method* (e.g. ``public void testX() { ... }``) it:
+
+  1. resolves the imports the method needs (project classes + JUnit asserts),
+  2. finds the existing test class most token-similar to the method,
+  3. injects the method (renamed ``<name>AutoGen``) plus any missing imports.
+
+`inject()` returns the ``Class::method`` identifier to pass to
+``defects4j test -t``. The renamed method always contains the substring
+``AutoGen`` so the runner can recognise it in the failing-test list.
+
+Requires the `javalang` package (`pip install javalang`).
+"""
+
+import os
+import re
+import codecs
+import subprocess as sp
+from os import path
+from collections import Counter, defaultdict
+
+import javalang
+
+
+# --------------------------------------------------------------------------- #
+# Small helpers
+# --------------------------------------------------------------------------- #
+def enforce_static_assertions(gen_test):
+    """Rewrite `Assert.fail`/`Assert.assertX` to the static-import form, so the
+    test compiles inside classes that statically import org.junit.Assert.*."""
+    if 'Assert.' in gen_test:
+        gen_test = gen_test.replace('Assert.fail', 'fail')
+        gen_test = gen_test.replace('Assert.assert', 'assert')
+    return gen_test
+
+
+def parse_method(gen_test):
+    tokens = javalang.tokenizer.tokenize(gen_test)
+    parser = javalang.parser.Parser(tokens)
+    return parser.parse_member_declaration()
+
+
+def get_most_common_item(iterator):
+    counts = Counter(iterator)
+    return max(counts.keys(), key=counts.__getitem__)
+
+
+# --------------------------------------------------------------------------- #
+# Import resolution
+# --------------------------------------------------------------------------- #
+def resolve_imports(repo_path, src_dir, gen_test):
+    """Return (classpaths, asserts) needed by the test method.
+
+    `classpaths` are fully-qualified project classes referenced by the method;
+    `asserts` are JUnit assertion method names used (assert*, fail).
+    `src_dir` is the project source dir relative to repo_path, WITH a trailing
+    slash (e.g. 'src/main/java/').
+    """
+    tree = parse_method(gen_test)
+
+    RelevantTypeClass = (javalang.tree.VariableDeclaration,
+                         javalang.tree.MemberReference,
+                         javalang.tree.MethodInvocation,
+                         javalang.tree.ReferenceType,
+                         javalang.tree.ClassCreator,)
+    ExceptionTypeClass = (javalang.tree.CatchClauseParameter,
+                          javalang.tree.MethodDeclaration,)
+
+    needed_class_stubs = set()
+    needed_asserts = set()
+    for _, node in tree:
+        if isinstance(node, ExceptionTypeClass):
+            exception_types = None
+            if isinstance(node, javalang.tree.CatchClauseParameter):
+                exception_types = node.types
+            elif isinstance(node, javalang.tree.MethodDeclaration):
+                exception_types = node.throws
+            if exception_types:
+                for exception_type in exception_types:
+                    needed_class_stubs.add(exception_type)
+        if isinstance(node, RelevantTypeClass):
+            if isinstance(node, javalang.tree.VariableDeclaration):
+                needed_class_stubs.add(node.type.name)
+            elif isinstance(node, javalang.tree.ReferenceType):
+                needed_class_stubs.add(node.name)
+            elif isinstance(node, javalang.tree.ClassCreator):
+                needed_class_stubs.add(node.type.name)
+            elif (isinstance(node, javalang.tree.MethodInvocation) and
+                  ('assert' in node.member or node.member == 'fail')):
+                needed_asserts.add(node.member)
+            elif isinstance(node, javalang.tree.MemberReference):
+                if (node.qualifier and len(node.qualifier) > 0 and
+                        node.qualifier[0].isupper()):
+                    needed_class_stubs.add(node.qualifier.split('.')[0])
+
+    classpaths = []
+    for class_stub in needed_class_stubs:
+        cp = sp.run(['find', src_dir, '-name', f'{class_stub}.java'],
+                    capture_output=True, cwd=repo_path)
+        out_lines = cp.stdout.decode('utf-8', 'ignore').split('\n')
+        if len(out_lines) != 2:
+            # 0 or >1 source files for this name: fall back to existing imports.
+            cp = sp.run(['grep', '-rh', r'import.*\.' + class_stub + ';', '.'],
+                        capture_output=True, cwd=repo_path)
+            example_paths = cp.stdout.decode('utf-8', 'ignore').split('\n')
+            example_paths = [e.removeprefix('import ').rstrip('\r').rstrip(';')
+                             for e in example_paths]
+            example_paths = [e for e in example_paths if e]
+            if len(example_paths) == 0:
+                if len(out_lines) == 1:
+                    continue  # not a project class (likely JDK / dependency)
+                filepath = out_lines[0]  # multiple matches, none imported: pick one
+                classpath = filepath.removeprefix(src_dir).removesuffix('.java')
+                classpath = classpath.replace('/', '.')
+            else:
+                classpath = get_most_common_item(example_paths)
+        else:
+            filepath = out_lines[0]
+            classpath = filepath.removeprefix(src_dir).removesuffix('.java')
+            classpath = classpath.replace('/', '.')
+        classpaths.append(classpath.strip('.'))
+    return classpaths, needed_asserts
+
+
+# --------------------------------------------------------------------------- #
+# Choosing the host test class
+# --------------------------------------------------------------------------- #
+def _is_injectable_test_class(file_content, filepath, titular_class_name):
+    """Abstract classes and @RunWith(Parameterized) classes cannot host a
+    plain injected method."""
+    tree = javalang.parse.parse(file_content)
+    titular_class_def = None
+    for _, node in tree.filter(javalang.tree.ClassDeclaration):
+        if node.name == titular_class_name:
+            titular_class_def = node
+            break
+    if titular_class_def is None:
+        return False
+    if 'abstract' in titular_class_def.modifiers:
+        return False
+    for annotation in titular_class_def.annotations:
+        if hasattr(annotation, 'element'):
+            anno = annotation.element
+            if hasattr(anno, 'type') and anno.type.name == 'Parameterized':
+                return False
+    return True
+
+
+def find_best_test_class(repo_path, test_dir, gen_test):
+    """Pick the existing test .java file whose token set best matches the
+    generated method. Returns (absolute_path, repo_relative_path)."""
+    file_scores = defaultdict(float)
+    test_tokens = set(e.value for e in javalang.tokenizer.tokenize(gen_test))
+
+    for root, _dirs, files in os.walk(path.join(repo_path, test_dir), topdown=False):
+        for name in [e for e in files if e.endswith('.java')]:
+            filepath = path.join(root, name)
+            with codecs.open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+                file_cont = f.read()
+            if 'abstract' in file_cont or '@RunWith(Parameterized.class)' in file_cont:
+                if not _is_injectable_test_class(file_cont, filepath, name.removesuffix('.java')):
+                    continue
+            if '@Ignore' in file_cont:
+                continue
+            file_tokens = set(e.value for e in javalang.tokenizer.tokenize(file_cont))
+            file_scores[filepath.removeprefix(repo_path)] += \
+                len(test_tokens & file_tokens) / len(test_tokens)
+
+    if not file_scores:
+        raise RuntimeError(f'No injectable test class found under {test_dir}')
+
+    best_file = sorted(file_scores.keys(),
+                       key=lambda x: (file_scores[x], x), reverse=True)[0]
+    if best_file.startswith('/'):
+        best_file = best_file[1:]
+    return path.join(repo_path, best_file), best_file
+
+
+# --------------------------------------------------------------------------- #
+# Import bookkeeping + actual injection
+# --------------------------------------------------------------------------- #
+def _derive_unhandled_imports(test_class_content, needed_classpaths, needed_class_stubs):
+    existing_imports = re.findall(r'import (.*);', test_class_content)
+
+    already_imported_stubs = []
+    for stub in needed_class_stubs:
+        for imp in existing_imports:
+            if imp.endswith(stub):
+                already_imported_stubs.append(stub)
+                break
+
+    unhandled_classpaths = []
+    for ncp in needed_classpaths:
+        if not any(ncp.endswith(stub) for stub in already_imported_stubs):
+            unhandled_classpaths.append(ncp)
+
+    unhandled_imports = []
+    for ncp in unhandled_classpaths:
+        ncp_package = '.'.join(ncp.split('.')[:-1])
+        search_terms = [
+            f'package {ncp_package};',
+            f'import {ncp};',
+            f'import static {ncp};',
+            f'import {ncp_package}.*;',
+            f'import static {ncp_package}.*;',
+        ]
+        if not any(term in test_class_content for term in search_terms):
+            unhandled_imports.append(ncp)
+    return unhandled_imports
+
+
+def _derive_unhandled_assert_imports(test_class_content, needed_asserts):
+    unhandled_imports = []
+    for na in needed_asserts:
+        ncp_form = f'static org.junit.Assert.{na}'
+        if f'import {ncp_form};' not in test_class_content:
+            unhandled_imports.append(ncp_form)
+    return unhandled_imports
+
+
+def _inject_with_imports(best_classpath, testf_lines, gen_test, unhandled_imports):
+    new_test_lines = testf_lines[:]
+
+    # Insert imports right after the package / before the first import.
+    import_loc = -1
+    for idx, line in enumerate(testf_lines):
+        if 'package' in line:
+            import_loc = idx + 1
+        if 'import' in line:
+            import_loc = idx
+            break
+    assert import_loc != -1, best_classpath
+    new_test_lines = (
+        new_test_lines[:import_loc] +
+        [f'import {ncp};\n' for ncp in unhandled_imports] +
+        new_test_lines[import_loc:]
+    )
+
+    # Rename the method to avoid collisions and tag it with AutoGen.
+    org_test_name = parse_method(gen_test).name
+    new_test_name = org_test_name + 'AutoGen'
+    gen_test = gen_test.replace('void ' + org_test_name, 'void ' + new_test_name)
+    if '@Test' in ''.join(testf_lines):
+        gen_test = '@Test\n' + gen_test.strip()
+
+    # Find the closing brace of the titular class and insert before it.
+    tree = javalang.parse.parse(''.join(new_test_lines))
+    is_titular_class = [(e.name == best_classpath.split('.')[-1]) for e in tree.types]
+    assert sum(is_titular_class) == 1, \
+        f'Class matching classpath {best_classpath} not found.'
+    titular_class_idx = is_titular_class.index(True)
+    if titular_class_idx + 1 == len(tree.types):
+        start_loc = len(new_test_lines) - 1
+    else:
+        start_loc = tree.types[titular_class_idx + 1]._position.line - 1
+
+    final_paren_loc = 0
+    for idx in range(start_loc, 0, -1):
+        if '}' in new_test_lines[idx]:
+            final_paren_loc = idx
+            break
+    assert final_paren_loc != 0
+    new_test_lines = (
+        new_test_lines[:final_paren_loc] +
+        [e + '\n' for e in gen_test.split('\n')] +
+        new_test_lines[final_paren_loc:]
+    )
+    return ''.join(new_test_lines), gen_test
+
+
+def inject(repo_path, src_dir, test_dir, gen_test):
+    """Inject `gen_test` into the best host test class of the checkout at
+    `repo_path`. Mutates that .java file on disk and returns the
+    ``Class::method`` name for `defects4j test -t`.
+
+    `src_dir` / `test_dir` are repo-relative dirs WITH trailing slash
+    (as returned by `defects4j export -p dir.src.classes / dir.src.tests`).
+    """
+    classpaths, asserts = resolve_imports(repo_path, src_dir, gen_test)
+    best_path, best_file = find_best_test_class(repo_path, test_dir, gen_test)
+
+    with codecs.open(best_path, 'r', encoding='utf-8', errors='ignore') as f:
+        testf_lines = f.readlines()
+    testf_content = ''.join(testf_lines)
+    needs_assert_imports = '@Test' in testf_content
+
+    class_stubs = [e.split('.')[-1] for e in classpaths]
+    unhandled = _derive_unhandled_imports(testf_content, classpaths, class_stubs)
+    if needs_assert_imports:
+        unhandled.extend(_derive_unhandled_assert_imports(testf_content, asserts))
+
+    best_classpath = best_file.removeprefix(test_dir).removesuffix('.java')
+    best_classpath = best_classpath.replace('/', '.').strip('.')
+
+    new_content, new_gen_test = _inject_with_imports(
+        best_classpath, testf_lines, gen_test, unhandled)
+
+    with open(best_path, 'w') as f:
+        f.write(new_content)
+
+    return f'{best_classpath}::' + parse_method(new_gen_test).name

--- a/simple_d4j_pipeline/java_utils.py
+++ b/simple_d4j_pipeline/java_utils.py
@@ -1,0 +1,57 @@
+"""Tiny Java text helpers shared across the pipeline."""
+
+import re
+
+
+def matching_brace(text, i):
+    """Index of the '}' matching the '{' at index `i`, skipping string/char
+    literals and comments. Returns -1 if unbalanced."""
+    assert text[i] == '{'
+    depth = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c in '"\'':
+            q = c
+            i += 1
+            while i < n:
+                if text[i] == '\\':
+                    i += 2
+                    continue
+                if text[i] == q:
+                    break
+                i += 1
+        elif c == '/' and i + 1 < n and text[i + 1] == '/':
+            nl = text.find('\n', i)
+            if nl == -1:
+                return -1
+            i = nl
+        elif c == '/' and i + 1 < n and text[i + 1] == '*':
+            end = text.find('*/', i + 2)
+            if end == -1:
+                return -1
+            i = end + 1
+        elif c == '{':
+            depth += 1
+        elif c == '}':
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def extract_method_by_name(text, method_name):
+    """Return the source of a method by name (literal/comment aware), or None."""
+    for m in re.finditer(r'\b' + re.escape(method_name) + r'\s*\(', text):
+        sig_start = max(text.rfind(';', 0, m.start()),
+                        text.rfind('{', 0, m.start()),
+                        text.rfind('}', 0, m.start())) + 1
+        brace = text.find('{', m.end() - 1)
+        if brace == -1:
+            continue
+        end = matching_brace(text, brace)
+        if end == -1:
+            continue
+        return text[sig_start:end + 1].strip()
+    return None

--- a/simple_d4j_pipeline/org_costs.py
+++ b/simple_d4j_pipeline/org_costs.py
@@ -1,0 +1,66 @@
+"""Query the OpenAI Organization Costs API for actual billed cost.
+
+This reconciles the token-based estimates from cost.py against what OpenAI
+actually billed. It hits GET /v1/organization/costs, which requires an
+*admin* API key (set OPENAI_ADMIN_KEY), not a regular project key.
+
+Docs: https://developers.openai.com/api/reference/python/resources/admin/subresources/organization/subresources/usage/methods/costs
+
+Usage:
+    OPENAI_ADMIN_KEY=sk-admin-... python org_costs.py --days 1
+"""
+
+import os
+import json
+import time
+import argparse
+import urllib.parse
+import urllib.request
+
+
+def fetch_costs(admin_key, start_time, end_time=None, bucket_width='1d', limit=31):
+    params = {'start_time': int(start_time), 'bucket_width': bucket_width, 'limit': limit}
+    if end_time:
+        params['end_time'] = int(end_time)
+    url = 'https://api.openai.com/v1/organization/costs?' + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, headers={'Authorization': f'Bearer {admin_key}'})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.load(resp)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--days', type=int, default=1,
+                    help='look back this many days (default 1)')
+    ap.add_argument('--start-time', type=int,
+                    help='explicit start unix time (overrides --days)')
+    ap.add_argument('--bucket-width', default='1d', choices=['1d'],
+                    help='cost bucket granularity (API currently supports 1d)')
+    args = ap.parse_args()
+
+    admin_key = os.environ.get('OPENAI_ADMIN_KEY')
+    if not admin_key:
+        raise SystemExit('Set OPENAI_ADMIN_KEY (an organization admin key).')
+
+    start = args.start_time or int(time.time() - args.days * 86400)
+    data = fetch_costs(admin_key, start)
+
+    total = 0.0
+    currency = 'usd'
+    for bucket in data.get('data', []):
+        bstart = bucket.get('start_time')
+        for res in bucket.get('results', []):
+            amount = (res.get('amount') or {})
+            val = amount.get('value', 0.0) or 0.0
+            currency = amount.get('currency', currency)
+            total += val
+            ts = time.strftime('%Y-%m-%d', time.gmtime(bstart)) if bstart else '?'
+            line = res.get('line_item') or res.get('project_id') or 'all'
+            print(f'  {ts}  {line}: {val:.4f} {currency}')
+    print(f'TOTAL billed since {time.strftime("%Y-%m-%d %H:%M", time.gmtime(start))} '
+          f'UTC: {total:.4f} {currency}')
+
+
+if __name__ == '__main__':
+    main()

--- a/simple_d4j_pipeline/patch_utils.py
+++ b/simple_d4j_pipeline/patch_utils.py
@@ -1,0 +1,153 @@
+"""Preprocess and apply the LLM-generated patches stored in the evaluation CSV.
+
+The patches in the CSV are `diff -r` outputs between absolute paths on the
+machine that generated them, e.g.
+
+    --- /data/.../result.bak/restore/source/src/main/java/org/jfree/.../X.java
+    +++ /data/.../source_ori-claude-sonnet-4/src/main/java/org/jfree/.../X.java
+
+while a Defects4J checkout stores the same class under the project's real
+source root (`source/...` for Chart, `src/...` for Closure, ...). We therefore
+reduce every header path to its *package path* (`org/jfree/.../X.java`), locate
+the matching file inside the checkout, and apply the hunks there with GNU
+`patch` (whitespace-insensitive, fuzzy) so layout differences don't matter.
+"""
+
+import os
+import re
+import tempfile
+import subprocess as sp
+from os import path
+
+
+def _clean_header_path(s):
+    """Strip the trailing diff timestamp (tab- or space-separated)."""
+    s = s.split('\t')[0]
+    s = re.sub(r'\s+\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.*$', '', s)
+    return s.strip()
+
+
+# Source roots, longest first; used to strip a path down to its package path.
+_SOURCE_ROOTS = [
+    'src/main/java/', 'src/test/java/', 'src/java/', 'src/test/',
+    'source/', 'tests/', 'test/', 'src/',
+]
+
+
+def package_path(p):
+    """Reduce a diff header path to the path relative to its source root,
+    e.g. '.../src/main/java/org/jfree/X.java' -> 'org/jfree/X.java'."""
+    best_end = None
+    for root in _SOURCE_ROOTS:
+        i = p.rfind(root)
+        if i != -1:
+            end = i + len(root)
+            if best_end is None or end > best_end:
+                best_end = end
+    return p[best_end:] if best_end is not None else p.split('/')[-1]
+
+
+def is_test_path(p):
+    """True if the header path points at a test source file."""
+    if '/src/test/' in p or '/test/' in p or '/tests/' in p:
+        return True
+    base = p.rstrip('/').split('/')[-1]
+    return base.endswith('Test.java') or base.endswith('Tests.java')
+
+
+def split_sections(patch_text):
+    """Split a (possibly multi-file) `diff -r` blob into per-file sections.
+
+    Returns a list of dicts: {'from', 'to', 'hunks': [lines]}.
+    `Only in ...` directory-listing lines are dropped.
+    """
+    lines = patch_text.splitlines()
+    sections = []
+    cur = None
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        if line.startswith('Only in '):
+            i += 1
+            continue
+        # A file header is a '--- ' line immediately followed by a '+++ ' line.
+        if line.startswith('--- ') and i + 1 < n and lines[i + 1].startswith('+++ '):
+            if cur is not None:
+                sections.append(cur)
+            cur = {
+                'from': _clean_header_path(line[4:]),
+                'to': _clean_header_path(lines[i + 1][4:]),
+                'hunks': [],
+            }
+            i += 2
+            continue
+        if line.startswith('diff '):
+            i += 1
+            continue
+        if cur is not None:
+            cur['hunks'].append(line)
+        i += 1
+    if cur is not None:
+        sections.append(cur)
+    # keep only sections that actually carry hunks
+    return [s for s in sections if any(h.startswith('@@') for h in s['hunks'])]
+
+
+def locate_file(repo, src_dir, pkg_path):
+    """Find the checkout file whose path ends with `pkg_path`.
+
+    Prefers an exact `<src_dir>/<pkg_path>` match; otherwise searches the repo.
+    Returns the repo-relative path, or None.
+    """
+    direct = path.join(src_dir.rstrip('/'), pkg_path)
+    if path.isfile(path.join(repo, direct)):
+        return direct
+    cp = sp.run(['find', '.', '-path', f'*/{pkg_path}'],
+                capture_output=True, cwd=repo)
+    matches = [m for m in cp.stdout.decode('utf-8', 'ignore').split('\n') if m]
+    if not matches:
+        return None
+    matches.sort(key=len)
+    return matches[0].removeprefix('./')
+
+
+def _apply_hunks(repo, target_rel, hunks):
+    """Apply `hunks` to `target_rel` (relative to repo) using GNU patch."""
+    body = '\n'.join([f'--- {target_rel}', f'+++ {target_rel}'] + hunks) + '\n'
+    with tempfile.NamedTemporaryFile('w', suffix='.patch', delete=False) as tf:
+        tf.write(body)
+        patch_file = tf.name
+    try:
+        proc = sp.run(
+            ['patch', '-p0', '-l', '--fuzz=3', '--no-backup-if-mismatch',
+             '-d', repo, '-i', patch_file],
+            capture_output=True)
+        return proc.returncode == 0, proc.stdout.decode('utf-8', 'ignore') + \
+            proc.stderr.decode('utf-8', 'ignore')
+    finally:
+        os.unlink(patch_file)
+
+
+def apply_llm_patch(repo, src_dir, patch_text, include_tests=False):
+    """Apply the production-source sections of an LLM patch to a checkout.
+
+    Returns (applied, skipped, failed) lists of repo-relative paths / messages.
+    """
+    applied, skipped, failed = [], [], []
+    for sec in split_sections(patch_text):
+        header = sec['to'] or sec['from']
+        if is_test_path(header) and not include_tests:
+            skipped.append(header)
+            continue
+        pkg = package_path(header)
+        target = locate_file(repo, src_dir, pkg)
+        if target is None:
+            failed.append((pkg, 'file not found in checkout'))
+            continue
+        ok, msg = _apply_hunks(repo, target, sec['hunks'])
+        if ok:
+            applied.append(target)
+        else:
+            failed.append((target, msg.strip().splitlines()[-1] if msg.strip() else 'patch failed'))
+    return applied, skipped, failed

--- a/simple_d4j_pipeline/patch_utils.py
+++ b/simple_d4j_pipeline/patch_utils.py
@@ -15,6 +15,7 @@ the matching file inside the checkout, and apply the hunks there with GNU
 
 import os
 import re
+import shutil
 import tempfile
 import subprocess as sp
 from os import path
@@ -129,10 +130,30 @@ def _apply_hunks(repo, target_rel, hunks):
         os.unlink(patch_file)
 
 
-def apply_llm_patch(repo, src_dir, patch_text, include_tests=False):
-    """Apply the production-source sections of an LLM patch to a checkout.
+def solution_rel_path(header):
+    """From a '+++' header like
+    /data/d4j_subjects/d4j_bugs/Chart-16/source_ori-claude-sonnet-4/src/main/java/org/.../X.java
+    return the part after '/d4j_bugs/' (i.e. the path under the solutions dir),
+    or None."""
+    marker = '/d4j_bugs/'
+    i = header.find(marker)
+    if i == -1:
+        return None
+    return header[i + len(marker):]
 
-    Returns (applied, skipped, failed) lists of repo-relative paths / messages.
+
+def apply_llm_patch(repo, src_dir, patch_text, include_tests=False,
+                    solutions_dir=None):
+    """Reproduce the LLM's changes on a checkout.
+
+    If `solutions_dir` is given (the on-disk path corresponding to
+    /data/d4j_subjects/d4j_bugs), each changed production file is replaced
+    wholesale with the LLM's full solution file -- robust against the
+    reformatting in the CSV diffs. Falls back to applying the diff hunks when
+    the full file isn't found.
+
+    Returns (applied, skipped, failed). `applied` entries note the method, e.g.
+    'src/.../X.java (full-file)'.
     """
     applied, skipped, failed = [], [], []
     for sec in split_sections(patch_text):
@@ -145,6 +166,17 @@ def apply_llm_patch(repo, src_dir, patch_text, include_tests=False):
         if target is None:
             failed.append((pkg, 'file not found in checkout'))
             continue
+
+        # Preferred: copy the LLM's full solution file over the checkout file.
+        if solutions_dir:
+            rel = solution_rel_path(header)
+            src_file = path.join(solutions_dir, rel) if rel else None
+            if src_file and path.isfile(src_file):
+                shutil.copyfile(src_file, path.join(repo, target))
+                applied.append(f'{target} (full-file)')
+                continue
+
+        # Fallback: apply the diff hunks.
         ok, msg = _apply_hunks(repo, target, sec['hunks'])
         if ok:
             applied.append(target)

--- a/simple_d4j_pipeline/plog.py
+++ b/simple_d4j_pipeline/plog.py
@@ -1,0 +1,20 @@
+"""Minimal timestamped logging shared across the pipeline scripts."""
+
+import sys
+import time
+
+
+def log(*args):
+    """Print a timestamped, flushed line."""
+    ts = time.strftime('%H:%M:%S')
+    print(f'[{ts}]', *args, flush=True)
+
+
+def block(title, content):
+    """Print a labelled, delimited multi-line block (e.g. a test method)."""
+    bar = '-' * 64
+    print(f'    {title}:')
+    print(f'    {bar}')
+    for line in (content or '<empty>').splitlines() or ['<empty>']:
+        print(f'    | {line}')
+    print(f'    {bar}', flush=True)

--- a/simple_d4j_pipeline/prepare_patched.py
+++ b/simple_d4j_pipeline/prepare_patched.py
@@ -64,13 +64,13 @@ def main():
     ap.add_argument('--csv', required=True, help='manual-evaluation CSV path')
     ap.add_argument('--repos-dir', required=True)
     ap.add_argument('-p', '--project', help='restrict to one project')
+    ap.add_argument('-b', '--bug', help='restrict to one bug id (use with -p)')
     ap.add_argument('--include-test-changes', action='store_true',
                     help='also apply the LLM patch to test files (default: skip)')
     args = ap.parse_args()
 
     bugs = csv_data.load_incorrect(args.csv)
-    targets = [(b, i) for b, i in sorted(bugs.items())
-               if not args.project or i['pid'] == args.project]
+    targets = csv_data.select(bugs, args.project, args.bug)
     n_variants = sum(len(i['incorrect']) for _, i in targets)
     plog.log(f'building buggy_<llm> checkouts: {len(targets)} bug(s), '
              f'{n_variants} variant(s)')

--- a/simple_d4j_pipeline/prepare_patched.py
+++ b/simple_d4j_pipeline/prepare_patched.py
@@ -1,0 +1,96 @@
+"""Build buggy_<llm> checkouts for every bug with an incorrect LLM patch.
+
+For each (bug, incorrect-model) pair we copy the bug's buggy checkout and apply
+the model's (production-source) patch on top, committing the result so the eval
+step's `git reset --hard` returns to the patched state.
+
+Prerequisite: checkout_all.sh has populated <repos>/<pid>_<bug>b.
+
+Usage:
+    python prepare_patched.py --csv eval.csv --repos-dir ./repos
+    python prepare_patched.py --csv eval.csv --repos-dir ./repos -p Chart
+    python prepare_patched.py --csv eval.csv --repos-dir ./repos --include-test-changes
+"""
+
+import os
+import shutil
+import argparse
+import subprocess as sp
+from os import path
+
+import csv_data
+import patch_utils
+
+
+def export_dir(repo, prop):
+    proc = sp.run(['defects4j', 'export', '-p', prop], capture_output=True, cwd=repo)
+    return proc.stdout.decode('utf-8', 'ignore').strip().rstrip('/') + '/'
+
+
+def git_commit_all(repo, message):
+    sp.run(['git', 'add', '-A'], cwd=repo, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+    sp.run(['git', '-c', 'user.email=pipeline@local', '-c', 'user.name=pipeline',
+            'commit', '-m', message, '--allow-empty'],
+           cwd=repo, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+
+
+def build_one(repos_dir, pid, bug, llm_key, patch_text, include_tests):
+    buggy = path.join(repos_dir, csv_data.repo_buggy(pid, bug))
+    target = path.join(repos_dir, csv_data.repo_llm(pid, bug, llm_key))
+
+    if not path.isdir(buggy):
+        return 'missing-buggy', None
+    if path.isdir(target):
+        return 'exists', None
+
+    sp.run(['cp', '-a', buggy, target], check=True)
+    src_dir = export_dir(target, 'dir.src.classes')
+    applied, skipped, failed = patch_utils.apply_llm_patch(
+        target, src_dir, patch_text, include_tests=include_tests)
+
+    if not applied:
+        # nothing applied -> not a usable variant; remove the copy
+        shutil.rmtree(target, ignore_errors=True)
+        return 'no-change', {'skipped': skipped, 'failed': failed}
+
+    git_commit_all(target, f'Apply incorrect {llm_key} patch')
+    return 'ok', {'applied': applied, 'skipped': skipped, 'failed': failed}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--csv', required=True, help='manual-evaluation CSV path')
+    ap.add_argument('--repos-dir', required=True)
+    ap.add_argument('-p', '--project', help='restrict to one project')
+    ap.add_argument('--include-test-changes', action='store_true',
+                    help='also apply the LLM patch to test files (default: skip)')
+    args = ap.parse_args()
+
+    bugs = csv_data.load_incorrect(args.csv)
+    counts = {'ok': 0, 'exists': 0, 'missing-buggy': 0, 'no-change': 0}
+    for bug_id, info in sorted(bugs.items()):
+        if args.project and info['pid'] != args.project:
+            continue
+        for llm_key, patch_text in info['incorrect']:
+            status, detail = build_one(
+                args.repos_dir, info['pid'], info['bug'], llm_key,
+                patch_text, args.include_test_changes)
+            counts[status] = counts.get(status, 0) + 1
+            tag = csv_data.repo_llm(info['pid'], info['bug'], llm_key)
+            if status == 'ok':
+                msg = f"applied={len(detail['applied'])}"
+                if detail['failed']:
+                    msg += f" FAILED={detail['failed']}"
+                print(f'[ok]   {tag}: {msg}')
+            elif status == 'no-change':
+                failed = detail['failed']
+                print(f'[warn] {tag}: nothing applied (failed={failed})')
+            elif status == 'missing-buggy':
+                print(f'[skip] {tag}: buggy checkout missing')
+            # 'exists' is silent-ish
+    print(f'[done] {counts}')
+
+
+if __name__ == '__main__':
+    main()

--- a/simple_d4j_pipeline/prepare_patched.py
+++ b/simple_d4j_pipeline/prepare_patched.py
@@ -20,6 +20,7 @@ from os import path
 
 import csv_data
 import patch_utils
+import plog
 
 
 def export_dir(repo, prop):
@@ -68,28 +69,34 @@ def main():
     args = ap.parse_args()
 
     bugs = csv_data.load_incorrect(args.csv)
+    targets = [(b, i) for b, i in sorted(bugs.items())
+               if not args.project or i['pid'] == args.project]
+    n_variants = sum(len(i['incorrect']) for _, i in targets)
+    plog.log(f'building buggy_<llm> checkouts: {len(targets)} bug(s), '
+             f'{n_variants} variant(s)')
+
     counts = {'ok': 0, 'exists': 0, 'missing-buggy': 0, 'no-change': 0}
-    for bug_id, info in sorted(bugs.items()):
-        if args.project and info['pid'] != args.project:
-            continue
+    done = 0
+    for bug_id, info in targets:
         for llm_key, patch_text in info['incorrect']:
+            done += 1
+            tag = csv_data.repo_llm(info['pid'], info['bug'], llm_key)
+            plog.log(f'[prep {done}/{n_variants}] {tag}')
             status, detail = build_one(
                 args.repos_dir, info['pid'], info['bug'], llm_key,
                 patch_text, args.include_test_changes)
             counts[status] = counts.get(status, 0) + 1
-            tag = csv_data.repo_llm(info['pid'], info['bug'], llm_key)
             if status == 'ok':
-                msg = f"applied={len(detail['applied'])}"
-                if detail['failed']:
-                    msg += f" FAILED={detail['failed']}"
-                print(f'[ok]   {tag}: {msg}')
+                plog.log(f'    OK: applied {detail["applied"]}'
+                         + (f'  skipped_tests={len(detail["skipped"])}' if detail['skipped'] else '')
+                         + (f'  FAILED={detail["failed"]}' if detail['failed'] else ''))
             elif status == 'no-change':
-                failed = detail['failed']
-                print(f'[warn] {tag}: nothing applied (failed={failed})')
+                plog.log(f'    warn: nothing applied (failed={detail["failed"]})')
             elif status == 'missing-buggy':
-                print(f'[skip] {tag}: buggy checkout missing')
-            # 'exists' is silent-ish
-    print(f'[done] {counts}')
+                plog.log(f'    skip: buggy checkout missing')
+            elif status == 'exists':
+                plog.log(f'    skip: already built')
+    plog.log(f'[done] {counts}')
 
 
 if __name__ == '__main__':

--- a/simple_d4j_pipeline/prepare_patched.py
+++ b/simple_d4j_pipeline/prepare_patched.py
@@ -35,7 +35,8 @@ def git_commit_all(repo, message):
            cwd=repo, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
 
 
-def build_one(repos_dir, pid, bug, llm_key, patch_text, include_tests):
+def build_one(repos_dir, pid, bug, llm_key, patch_text, include_tests,
+              solutions_dir=None):
     buggy = path.join(repos_dir, csv_data.repo_buggy(pid, bug))
     target = path.join(repos_dir, csv_data.repo_llm(pid, bug, llm_key))
 
@@ -47,7 +48,8 @@ def build_one(repos_dir, pid, bug, llm_key, patch_text, include_tests):
     sp.run(['cp', '-a', buggy, target], check=True)
     src_dir = export_dir(target, 'dir.src.classes')
     applied, skipped, failed = patch_utils.apply_llm_patch(
-        target, src_dir, patch_text, include_tests=include_tests)
+        target, src_dir, patch_text, include_tests=include_tests,
+        solutions_dir=solutions_dir)
 
     if not applied:
         # nothing applied -> not a usable variant; remove the copy
@@ -67,6 +69,10 @@ def main():
     ap.add_argument('-b', '--bug', help='restrict to one bug id (use with -p)')
     ap.add_argument('--include-test-changes', action='store_true',
                     help='also apply the LLM patch to test files (default: skip)')
+    ap.add_argument('--solutions-dir',
+                    help='on-disk path corresponding to /data/d4j_subjects/d4j_bugs; '
+                         'when set, copies each LLM full solution file instead of '
+                         'applying the (reformatted) diff. Diff is used as fallback.')
     args = ap.parse_args()
 
     bugs = csv_data.load_incorrect(args.csv)
@@ -84,7 +90,7 @@ def main():
             plog.log(f'[prep {done}/{n_variants}] {tag}')
             status, detail = build_one(
                 args.repos_dir, info['pid'], info['bug'], llm_key,
-                patch_text, args.include_test_changes)
+                patch_text, args.include_test_changes, args.solutions_dir)
             counts[status] = counts.get(status, 0) + 1
             if status == 'ok':
                 plog.log(f'    OK: applied {detail["applied"]}'

--- a/simple_d4j_pipeline/report_stats.py
+++ b/simple_d4j_pipeline/report_stats.py
@@ -1,0 +1,64 @@
+"""Summarise augmented-test evaluation results.
+
+Usage:
+    python report_stats.py --results aug_results.json
+    python report_stats.py --results aug_results.json --by-project
+"""
+
+import json
+import argparse
+from collections import Counter, defaultdict
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--results', required=True)
+    ap.add_argument('--by-project', action='store_true')
+    args = ap.parse_args()
+
+    with open(args.results) as f:
+        results = json.load(f)
+
+    total = len(results)
+    correct = sum(1 for r in results.values() if r['correctly_augmented'])
+
+    # Per-version status tallies, plus the three success conditions.
+    fixed_pass = sum(1 for r in results.values() if r['versions'].get('fixed') == 'pass')
+    buggy_fail = sum(1 for r in results.values() if r['versions'].get('buggy') == 'fail')
+    all_llm_fail = sum(
+        1 for r in results.values()
+        if r['llm_variants'] and all(r['versions'][v] == 'fail' for v in r['llm_variants']))
+
+    fixed_status = Counter(r['versions'].get('fixed') for r in results.values())
+    buggy_status = Counter(r['versions'].get('buggy') for r in results.values())
+    llm_status = Counter(
+        r['versions'][v] for r in results.values() for v in r['llm_variants'])
+
+    pct = lambda n: f'{100 * n / total:.1f}%' if total else 'n/a'
+
+    print(f'Bugs evaluated:        {total}')
+    print(f'Correctly augmented:   {correct}  ({pct(correct)})')
+    print('-' * 48)
+    print(f'  pass on fixed:       {fixed_pass}  ({pct(fixed_pass)})')
+    print(f'  fail on buggy:       {buggy_fail}  ({pct(buggy_fail)})')
+    print(f'  fail on all buggy_llm: {all_llm_fail}  ({pct(all_llm_fail)})')
+    print('-' * 48)
+    print(f'  fixed status:        {dict(fixed_status)}')
+    print(f'  buggy status:        {dict(buggy_status)}')
+    print(f'  buggy_llm status:    {dict(llm_status)}  '
+          f'({sum(llm_status.values())} variants)')
+
+    if args.by_project:
+        per = defaultdict(lambda: [0, 0])
+        for r in results.values():
+            per[r['pid']][0] += 1
+            per[r['pid']][1] += int(r['correctly_augmented'])
+        print('-' * 48)
+        print('By project (correct / total):')
+        for pid in sorted(per):
+            tot, ok = per[pid]
+            print(f'  {pid:<18} {ok}/{tot}')
+
+
+if __name__ == '__main__':
+    main()

--- a/simple_d4j_pipeline/report_stats.py
+++ b/simple_d4j_pipeline/report_stats.py
@@ -67,6 +67,30 @@ def main():
             for s in statuses)
         print(f'  {v:<{name_w}}  {n:>4}  {cells}')
 
+    # Per-LLM-variant success: for each LLM whose incorrect patch produced a
+    # buggy_<llm>, how many bugs does the augmented test correctly distinguish
+    # (pass on fixed + fail on buggy + fail on THIS variant) out of how many
+    # bugs have a variant for this LLM.
+    per_llm = defaultdict(lambda: [0, 0])   # llm_key -> [correct, total]
+    for r in results.values():
+        fixed_ok = r['versions'].get('fixed') == 'pass'
+        buggy_fail = r['versions'].get('buggy') == 'fail'
+        for v in r['llm_variants']:
+            key = v[len('buggy_'):] if v.startswith('buggy_') else v
+            per_llm[key][1] += 1
+            if fixed_ok and buggy_fail and r['versions'].get(v) == 'fail':
+                per_llm[key][0] += 1
+
+    if per_llm:
+        print('-' * 64)
+        print('Per-LLM success (pass fixed & fail buggy & fail this variant):')
+        lw = max(len(k) for k in per_llm)
+        print(f'  {"llm":<{lw}}  {"correct/total":>14}     %')
+        for key in sorted(per_llm):
+            ok, tot = per_llm[key]
+            pctn = f'{100 * ok / tot:>4.0f}%' if tot else '  n/a'
+            print(f'  {key:<{lw}}  {ok:>6}/{tot:<7}  {pctn}')
+
     if args.by_project:
         per = defaultdict(lambda: [0, 0])
         for r in results.values():

--- a/simple_d4j_pipeline/report_stats.py
+++ b/simple_d4j_pipeline/report_stats.py
@@ -22,31 +22,50 @@ def main():
     total = len(results)
     correct = sum(1 for r in results.values() if r['correctly_augmented'])
 
-    # Per-version status tallies, plus the three success conditions.
+    # Three success conditions.
     fixed_pass = sum(1 for r in results.values() if r['versions'].get('fixed') == 'pass')
     buggy_fail = sum(1 for r in results.values() if r['versions'].get('buggy') == 'fail')
     all_llm_fail = sum(
         1 for r in results.values()
         if r['llm_variants'] and all(r['versions'][v] == 'fail' for v in r['llm_variants']))
 
-    fixed_status = Counter(r['versions'].get('fixed') for r in results.values())
-    buggy_status = Counter(r['versions'].get('buggy') for r in results.values())
-    llm_status = Counter(
-        r['versions'][v] for r in results.values() for v in r['llm_variants'])
+    # Per-version status counts (every distinct version name across all bugs).
+    per_version = defaultdict(Counter)
+    for r in results.values():
+        for vname, status in r['versions'].items():
+            per_version[vname][status] += 1
 
     pct = lambda n: f'{100 * n / total:.1f}%' if total else 'n/a'
 
     print(f'Bugs evaluated:        {total}')
     print(f'Correctly augmented:   {correct}  ({pct(correct)})')
-    print('-' * 48)
-    print(f'  pass on fixed:       {fixed_pass}  ({pct(fixed_pass)})')
-    print(f'  fail on buggy:       {buggy_fail}  ({pct(buggy_fail)})')
+    print('-' * 64)
+    print(f'  pass on fixed:         {fixed_pass}  ({pct(fixed_pass)})')
+    print(f'  fail on buggy:         {buggy_fail}  ({pct(buggy_fail)})')
     print(f'  fail on all buggy_llm: {all_llm_fail}  ({pct(all_llm_fail)})')
-    print('-' * 48)
-    print(f'  fixed status:        {dict(fixed_status)}')
-    print(f'  buggy status:        {dict(buggy_status)}')
-    print(f'  buggy_llm status:    {dict(llm_status)}  '
-          f'({sum(llm_status.values())} variants)')
+    print('-' * 64)
+
+    # Order versions: fixed, buggy, then llm variants alphabetically.
+    canonical = []
+    if 'fixed' in per_version:
+        canonical.append('fixed')
+    if 'buggy' in per_version:
+        canonical.append('buggy')
+    canonical += sorted(v for v in per_version if v not in ('fixed', 'buggy'))
+
+    statuses = ('pass', 'fail', 'compile_error', 'error')
+    name_w = max((len(v) for v in canonical), default=12)
+    header = (f'  {"version":<{name_w}}  {"n":>4}  ' +
+              '  '.join(f'{s:>13}' for s in statuses))
+    print('Per-version status:')
+    print(header)
+    for v in canonical:
+        c = per_version[v]
+        n = sum(c.values())
+        cells = '  '.join(
+            f'{c[s]:>5} ({100 * c[s] / n:>4.0f}%)' if n else f'{"-":>13}'
+            for s in statuses)
+        print(f'  {v:<{name_w}}  {n:>4}  {cells}')
 
     if args.by_project:
         per = defaultdict(lambda: [0, 0])

--- a/simple_d4j_pipeline/report_stats.py
+++ b/simple_d4j_pipeline/report_stats.py
@@ -67,29 +67,63 @@ def main():
             for s in statuses)
         print(f'  {v:<{name_w}}  {n:>4}  {cells}')
 
-    # Per-LLM-variant success: for each LLM whose incorrect patch produced a
-    # buggy_<llm>, how many bugs does the augmented test correctly distinguish
-    # (pass on fixed + fail on buggy + fail on THIS variant) out of how many
-    # bugs have a variant for this LLM.
-    per_llm = defaultdict(lambda: [0, 0])   # llm_key -> [correct, total]
+    # Per-LLM patch kill rate.
+    # success = test passes on fixed AND fails on buggy AND fails on THIS llm variant.
+    # Denominator is total bugs evaluated (bugs without this llm's variant
+    # contribute to the denominator but can never be a kill).
+    all_llms = sorted({v[len('buggy_'):] if v.startswith('buggy_') else v
+                       for r in results.values() for v in r['llm_variants']})
+    per_llm_killed = defaultdict(int)
     for r in results.values():
-        fixed_ok = r['versions'].get('fixed') == 'pass'
-        buggy_fail = r['versions'].get('buggy') == 'fail'
+        if r['versions'].get('fixed') != 'pass' or r['versions'].get('buggy') != 'fail':
+            continue
         for v in r['llm_variants']:
-            key = v[len('buggy_'):] if v.startswith('buggy_') else v
-            per_llm[key][1] += 1
-            if fixed_ok and buggy_fail and r['versions'].get(v) == 'fail':
-                per_llm[key][0] += 1
+            if r['versions'].get(v) == 'fail':
+                key = v[len('buggy_'):] if v.startswith('buggy_') else v
+                per_llm_killed[key] += 1
 
-    if per_llm:
+    if all_llms:
         print('-' * 64)
-        print('Per-LLM success (pass fixed & fail buggy & fail this variant):')
-        lw = max(len(k) for k in per_llm)
-        print(f'  {"llm":<{lw}}  {"correct/total":>14}     %')
-        for key in sorted(per_llm):
-            ok, tot = per_llm[key]
-            pctn = f'{100 * ok / tot:>4.0f}%' if tot else '  n/a'
-            print(f'  {key:<{lw}}  {ok:>6}/{tot:<7}  {pctn}')
+        print(f'Per-LLM patch kill rate '
+              f'(pass fixed & fail buggy & fail this llm; total = {total} bugs):')
+        lw = max(len(k) for k in all_llms)
+        print(f'  {"llm":<{lw}}  {"killed/total":>14}     %')
+        for key in all_llms:
+            k = per_llm_killed[key]
+            pctn = f'{100 * k / total:>4.0f}%' if total else 'n/a'
+            print(f'  {key:<{lw}}  {k:>6}/{total:<7}  {pctn}')
+
+    # Test-quality / distinguishability insights.
+    regression_valid = [
+        r for r in results.values()
+        if r['versions'].get('fixed') == 'pass' and r['versions'].get('buggy') == 'fail'
+    ]
+    n_reg = len(regression_valid)
+    n_kill_any = sum(
+        1 for r in regression_valid
+        if any(r['versions'].get(v) == 'fail' for v in r['llm_variants']))
+    n_kill_all = sum(
+        1 for r in regression_valid
+        if r['llm_variants']
+        and all(r['versions'].get(v) == 'fail' for v in r['llm_variants']))
+
+    print('-' * 64)
+    print('Augmented-test quality:')
+    print(f'  regression-valid (pass fixed & fail buggy):    {n_reg}/{total}  ({pct(n_reg)})')
+    print(f'    .. of which kill >=1 llm variant:            {n_kill_any}/{total}  ({pct(n_kill_any)})')
+    print(f'    .. of which kill ALL llm variants (== correctly augmented): '
+          f'{n_kill_all}/{total}  ({pct(n_kill_all)})')
+
+    # Distribution of (#variants killed, #variants for that bug) among regression-valid tests.
+    dist = Counter()
+    for r in regression_valid:
+        nv = len(r['llm_variants'])
+        nk = sum(1 for v in r['llm_variants'] if r['versions'].get(v) == 'fail')
+        dist[(nk, nv)] += 1
+    if dist:
+        print('  kill distribution (killed/variants -> # regression-valid bugs):')
+        for (nk, nv), c in sorted(dist.items()):
+            print(f'    {nk}/{nv}:  {c}')
 
     if args.by_project:
         per = defaultdict(lambda: [0, 0])

--- a/simple_d4j_pipeline/report_stats.py
+++ b/simple_d4j_pipeline/report_stats.py
@@ -30,10 +30,18 @@ def main():
         if r['llm_variants'] and all(r['versions'][v] == 'fail' for v in r['llm_variants']))
 
     # Per-version status counts (every distinct version name across all bugs).
+    # `n/a` covers bugs that don't have that variant, so every row sums to
+    # `total` (the number of bugs / augmented tests).
     per_version = defaultdict(Counter)
+    all_versions = set()
     for r in results.values():
-        for vname, status in r['versions'].items():
-            per_version[vname][status] += 1
+        all_versions.update(r['versions'].keys())
+    for r in results.values():
+        for vname in all_versions:
+            if vname in r['versions']:
+                per_version[vname][r['versions'][vname]] += 1
+            else:
+                per_version[vname]['n/a'] += 1
 
     pct = lambda n: f'{100 * n / total:.1f}%' if total else 'n/a'
 
@@ -53,19 +61,18 @@ def main():
         canonical.append('buggy')
     canonical += sorted(v for v in per_version if v not in ('fixed', 'buggy'))
 
-    statuses = ('pass', 'fail', 'compile_error', 'error')
+    statuses = ('pass', 'fail', 'compile_error', 'error', 'n/a')
     name_w = max((len(v) for v in canonical), default=12)
-    header = (f'  {"version":<{name_w}}  {"n":>4}  ' +
+    header = (f'  {"version":<{name_w}}  {"total":>5}  ' +
               '  '.join(f'{s:>13}' for s in statuses))
-    print('Per-version status:')
+    print(f'Per-version status (total = {total} bugs / augmented tests):')
     print(header)
     for v in canonical:
         c = per_version[v]
-        n = sum(c.values())
         cells = '  '.join(
-            f'{c[s]:>5} ({100 * c[s] / n:>4.0f}%)' if n else f'{"-":>13}'
+            f'{c[s]:>5} ({100 * c[s] / total:>4.0f}%)' if total else f'{"-":>13}'
             for s in statuses)
-        print(f'  {v:<{name_w}}  {n:>4}  {cells}')
+        print(f'  {v:<{name_w}}  {total:>5}  {cells}')
 
     # Per-LLM patch kill rate.
     # success = test passes on fixed AND fails on buggy AND fails on THIS llm variant.

--- a/simple_d4j_pipeline/requirements.txt
+++ b/simple_d4j_pipeline/requirements.txt
@@ -1,0 +1,5 @@
+# Java source parsing / test injection (injector.py, run_pipeline.py, eval_augmented.py)
+javalang>=0.13.0
+
+# OpenAI API for augmented-test generation (gen_augmented.py only)
+openai>=1.0.0

--- a/simple_d4j_pipeline/run_pipeline.py
+++ b/simple_d4j_pipeline/run_pipeline.py
@@ -1,0 +1,209 @@
+"""Run LLM-generated Defects4J tests and report fail-in-buggy / pass-in-fixed.
+
+A simplified re-implementation of libro's `postprocess_d4j.py`. For each bug it
+injects every candidate test method into BOTH the buggy and the fixed checkout,
+compiles, runs the single test via `defects4j test -t`, and marks a candidate
+"success" when it fails on the buggy version but passes on the fixed version
+(i.e. a genuine bug-reproducing test).
+
+Expected on-disk layout (produced by checkout_all.sh):
+    REPOS_DIR/<Project>_<bug>b   buggy checkout
+    REPOS_DIR/<Project>_<bug>f   fixed checkout
+
+Generated tests (one bare JUnit method per file, optionally ```-fenced):
+    TESTS_DIR/<Project>_<bug>_*.txt
+e.g.  Time_18_n0.txt, Time_18_n1.txt, Lang_5_attempt3.txt ...
+
+Usage:
+    # everything found in the tests dir
+    python run_pipeline.py --tests-dir ./gen_tests --repos-dir ./repos --out results.json
+
+    # a single bug (handy for debugging)
+    python run_pipeline.py --tests-dir ./gen_tests --repos-dir ./repos -p Time -b 18
+
+Results are written incrementally to --out, so the run can be interrupted and
+resumed-by-rerun without losing completed bugs.
+"""
+
+import os
+import glob
+import json
+import argparse
+import subprocess as sp
+from os import path
+
+import injector
+
+
+TEST_TIMEOUT = '1m'   # per-test wall-clock cap passed to `timeout`
+
+
+def strip_fences(text):
+    """Remove a leading ``` / ```java fence line and a trailing ``` fence."""
+    text = text.strip()
+    if text.startswith('```'):
+        text = text.split('\n', 1)[1] if '\n' in text else ''
+    if text.rstrip().endswith('```'):
+        text = text.rstrip()[:-3]
+    return text.strip()
+
+
+def export_dir(repo, prop):
+    """Return a repo-relative dir (with trailing slash) from defects4j export."""
+    p = sp.run(['defects4j', 'export', '-p', prop], capture_output=True, cwd=repo)
+    return p.stdout.decode('utf-8', 'ignore').strip().rstrip('/') + '/'
+
+
+def git_reset_clean(repo):
+    sp.run(['git', 'reset', '--hard', 'HEAD'], cwd=repo,
+           stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+    sp.run(['git', 'clean', '-df'], cwd=repo,
+           stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+
+
+def compile_repo(repo):
+    """Return (returncode, filtered_compile_error_message)."""
+    proc = sp.run(['defects4j', 'compile'],
+                  stdout=sp.PIPE, stderr=sp.PIPE, cwd=repo)
+    lines = proc.stderr.decode('utf-8', 'ignore').split('\n')[2:]
+    lines = [e for e in lines
+             if '[javac] [' not in e and '[javac]' in e
+             and 'warning:' not in e and '[javac] Note:' not in e
+             and 'compiler be upgraded.' not in e]
+    return proc.returncode, '\n'.join(lines)
+
+
+def run_test(repo, test_name):
+    """Run one test. Returns (status, failed_tests).
+
+    status:  0 normal,  -1 no output (likely runtime/timeout failure)."""
+    proc = sp.run(['timeout', TEST_TIMEOUT, 'defects4j', 'test', '-t', test_name],
+                  capture_output=True, cwd=repo)
+    out = proc.stdout.decode('utf-8', 'ignore')
+    if len(out) == 0:
+        return -1, []
+    lines = out.split('\n')
+    failed_tests = [e.strip(' - ') for e in lines[1:] if len(e) > 1]
+    return 0, failed_tests
+
+
+def run_one(repo, gen_test, src_dir, test_dir):
+    """Inject + compile + run a single candidate test in one checkout."""
+    git_reset_clean(repo)
+    gen_test = injector.enforce_static_assertions(gen_test)
+    test_name = injector.inject(repo, src_dir, test_dir, gen_test)
+
+    returncode, compile_msg = compile_repo(repo)
+    if returncode != 0:
+        return {
+            'compile_error': True, 'runtime_error': False,
+            'failed_tests': [], 'autogen_failed': False,
+            'error_msg': None, 'compile_msg': compile_msg,
+        }
+
+    status, failed_tests = run_test(repo, test_name)
+    error_msg = None
+    if failed_tests:
+        ft_path = path.join(repo, 'failing_tests')
+        if path.exists(ft_path):
+            with open(ft_path) as f:
+                error_msg = ''.join(f.readlines()[:5])
+    return {
+        'compile_error': False, 'runtime_error': status == -1,
+        'failed_tests': failed_tests, 'autogen_failed': len(failed_tests) > 0,
+        'error_msg': error_msg, 'compile_msg': None,
+    }
+
+
+def fails_autogen(info):
+    return any('AutoGen' in t for t in info['failed_tests'])
+
+
+def eval_bug(proj, bug, tests_dir, repos_dir):
+    """Evaluate all candidate tests for one bug. Returns {filename: result}."""
+    buggy = path.join(repos_dir, f'{proj}_{bug}b')
+    fixed = path.join(repos_dir, f'{proj}_{bug}f')
+    if not path.isdir(buggy) or not path.isdir(fixed):
+        print(f'[skip] missing buggy/fixed checkout for {proj}-{bug}')
+        return None
+
+    test_files = sorted(glob.glob(path.join(tests_dir, f'{proj}_{bug}_*.txt')))
+    if not test_files:
+        return None
+
+    tests = []
+    for fp in test_files:
+        with open(fp) as f:
+            tests.append(strip_fences(f.read()))
+
+    per_version = {}
+    for tag, repo in (('buggy', buggy), ('fixed', fixed)):
+        src_dir = export_dir(repo, 'dir.src.classes')
+        test_dir = export_dir(repo, 'dir.src.tests')
+        outcomes = []
+        for gen_test in tests:
+            try:
+                outcomes.append(run_one(repo, gen_test, src_dir, test_dir))
+            except Exception as e:  # parse / injection failure -> record, keep going
+                outcomes.append(f'[error] {repr(e)}')
+        per_version[tag] = outcomes
+
+    results = {}
+    for fp, b_info, f_info in zip(test_files, per_version['buggy'], per_version['fixed']):
+        name = path.basename(fp)
+        if isinstance(b_info, str) or isinstance(f_info, str):
+            results[name] = {'buggy': b_info, 'fixed': f_info, 'success': False}
+            continue
+        success = fails_autogen(b_info) and not fails_autogen(f_info)
+        results[name] = {'buggy': b_info, 'fixed': f_info, 'success': success}
+    return results
+
+
+def discover_bugs(tests_dir):
+    """Infer (project, bug) pairs from generated-test filenames."""
+    keys = set()
+    for fp in glob.glob(path.join(tests_dir, '*.txt')):
+        parts = path.basename(fp).split('_')
+        if len(parts) >= 3 and parts[1].isdigit():
+            keys.add((parts[0], parts[1]))
+    return sorted(keys, key=lambda x: (x[0], int(x[1])))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--tests-dir', required=True,
+                    help='dir with <Project>_<bug>_*.txt generated test methods')
+    ap.add_argument('--repos-dir', required=True,
+                    help='dir with <Project>_<bug>b / <Project>_<bug>f checkouts')
+    ap.add_argument('--out', default='results.json', help='output JSON path')
+    ap.add_argument('-p', '--project', help='restrict to one project')
+    ap.add_argument('-b', '--bug', help='restrict to one bug id (needs -p)')
+    args = ap.parse_args()
+
+    if args.project and args.bug:
+        bugs = [(args.project, args.bug)]
+    else:
+        bugs = discover_bugs(args.tests_dir)
+
+    all_results = {}
+    n_success = 0
+    for proj, bug in bugs:
+        print(f'=== {proj}-{bug} ===', flush=True)
+        res = eval_bug(proj, bug, args.tests_dir, args.repos_dir)
+        if res is None:
+            continue
+        all_results[f'{proj}_{bug}'] = res
+        bug_success = sum(1 for r in res.values() if r['success'])
+        n_success += bug_success
+        print(f'    {bug_success}/{len(res)} candidate tests reproduce the bug',
+              flush=True)
+        with open(args.out, 'w') as f:
+            json.dump(all_results, f, indent=2)
+
+    print(f'[done] {n_success} reproducing tests across {len(all_results)} bugs '
+          f'-> {args.out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/simple_d4j_pipeline/run_pipeline.py
+++ b/simple_d4j_pipeline/run_pipeline.py
@@ -33,6 +33,7 @@ import subprocess as sp
 from os import path
 
 import injector
+import plog
 
 
 TEST_TIMEOUT = '1m'   # per-test wall-clock cap passed to `timeout`
@@ -136,12 +137,13 @@ def eval_bug(proj, bug, tests_dir, repos_dir):
         with open(fp) as f:
             tests.append(strip_fences(f.read()))
 
+    plog.log(f'    {len(tests)} candidate test(s)')
     per_version = {}
     for tag, repo in (('buggy', buggy), ('fixed', fixed)):
         src_dir = export_dir(repo, 'dir.src.classes')
         test_dir = export_dir(repo, 'dir.src.tests')
         outcomes = []
-        for gen_test in tests:
+        for i, gen_test in enumerate(tests):
             try:
                 outcomes.append(run_one(repo, gen_test, src_dir, test_dir))
             except Exception as e:  # parse / injection failure -> record, keep going
@@ -153,8 +155,12 @@ def eval_bug(proj, bug, tests_dir, repos_dir):
         name = path.basename(fp)
         if isinstance(b_info, str) or isinstance(f_info, str):
             results[name] = {'buggy': b_info, 'fixed': f_info, 'success': False}
+            plog.log(f'    {name}: error  buggy={b_info if isinstance(b_info,str) else "ok"} '
+                     f'fixed={f_info if isinstance(f_info,str) else "ok"}')
             continue
         success = fails_autogen(b_info) and not fails_autogen(f_info)
+        plog.log(f'    {name}: buggy={"fail" if fails_autogen(b_info) else "pass"} '
+                 f'fixed={"fail" if fails_autogen(f_info) else "pass"} -> success={success}')
         results[name] = {'buggy': b_info, 'fixed': f_info, 'success': success}
     return results
 
@@ -186,23 +192,23 @@ def main():
     else:
         bugs = discover_bugs(args.tests_dir)
 
+    plog.log(f'running FIB evaluation for {len(bugs)} bug(s)')
     all_results = {}
     n_success = 0
-    for proj, bug in bugs:
-        print(f'=== {proj}-{bug} ===', flush=True)
+    for idx, (proj, bug) in enumerate(bugs, 1):
+        plog.log(f'=== [{idx}/{len(bugs)}] {proj}-{bug} ===')
         res = eval_bug(proj, bug, args.tests_dir, args.repos_dir)
         if res is None:
             continue
         all_results[f'{proj}_{bug}'] = res
         bug_success = sum(1 for r in res.values() if r['success'])
         n_success += bug_success
-        print(f'    {bug_success}/{len(res)} candidate tests reproduce the bug',
-              flush=True)
+        plog.log(f'    {bug_success}/{len(res)} candidate test(s) reproduce the bug')
         with open(args.out, 'w') as f:
             json.dump(all_results, f, indent=2)
 
-    print(f'[done] {n_success} reproducing tests across {len(all_results)} bugs '
-          f'-> {args.out}')
+    plog.log(f'[done] {n_success} reproducing tests across {len(all_results)} bugs '
+             f'-> {args.out}')
 
 
 if __name__ == '__main__':

--- a/simple_d4j_pipeline/try_k.py
+++ b/simple_d4j_pipeline/try_k.py
@@ -1,0 +1,184 @@
+"""Run the augmented-test pipeline on k diverse bugs across several models.
+
+Selects k bugs (default 30) that have >=1 incorrect patch, spread across
+projects (round-robin, deterministic with --seed). Builds the shared checkouts
+and buggy_<llm> variants ONCE (they don't depend on the generation model), then
+for each generation model runs generation + evaluation into its own folder:
+
+    <out-dir>/selected_bugs.csv      the filtered CSV driving every step
+    <out-dir>/<model>/aug_tests/     generated tests + records/ + cost.json
+    <out-dir>/<model>/aug_results.json
+    <out-dir>/summary.json           correct/total + cost per model
+
+Usage:
+    OPENAI_API_KEY=... python try_k.py --csv eval.csv \
+        --models gpt-5-mini gpt-5.2 gpt-5.4-mini \
+        --src-dir .. --out-dir ./results_k -k 30
+
+--src-dir is the parent holding <Project>-<bug>/{buggy,fixed,source_*}; when
+set, checkouts are copied from there and it doubles as --solutions-dir.
+"""
+
+import os
+import sys
+import csv
+import json
+import random
+import argparse
+import subprocess as sp
+from os import path
+from collections import defaultdict
+
+import csv_data
+import plog
+
+HERE = path.dirname(path.abspath(__file__))
+
+
+def select_diverse(bugs, k, seed):
+    """Pick k bug ids spread across projects (round-robin, seeded)."""
+    rng = random.Random(seed)
+    by_proj = defaultdict(list)
+    for bug_id, info in bugs.items():
+        by_proj[info['pid']].append(bug_id)
+    for ids in by_proj.values():
+        rng.shuffle(ids)
+    projects = sorted(by_proj)
+    rng.shuffle(projects)
+
+    selected = []
+    while len(selected) < k:
+        progressed = False
+        for p in projects:
+            if by_proj[p]:
+                selected.append(by_proj[p].pop())
+                progressed = True
+                if len(selected) >= k:
+                    break
+        if not progressed:
+            break
+    return selected
+
+
+def write_filtered_csv(csv_path, keep_ids, out_path):
+    with open(csv_path, newline='') as f:
+        rows = list(csv.reader(f))
+    keep = set(keep_ids)
+    out_rows = [rows[0]] + [r for r in rows[1:] if len(r) > 1 and r[1] in keep]
+    with open(out_path, 'w', newline='') as f:
+        csv.writer(f).writerows(out_rows)
+
+
+def ensure_checkouts(repos_dir, selected, bugs, src_dir):
+    for bug_id in selected:
+        info = bugs[bug_id]
+        pid, bug = info['pid'], info['bug']
+        for sub, suf in (('buggy', 'b'), ('fixed', 'f')):
+            dest = path.join(repos_dir, f'{pid}_{bug}{suf}')
+            if path.isdir(dest):
+                continue
+            src = path.join(src_dir, f'{pid}-{bug}', sub) if src_dir else None
+            if src and path.isdir(src):
+                sp.run(['cp', '-a', src, dest], check=True)
+            else:
+                sp.run(['defects4j', 'checkout', '-p', pid, '-v', f'{bug}{suf}',
+                        '-w', dest], check=True)
+
+
+def run(cmd):
+    plog.log('$ ' + ' '.join(cmd))
+    sp.run(cmd, check=False)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--csv', required=True)
+    ap.add_argument('--models', nargs='+', required=True,
+                    help='generation models to sweep (space- or comma-separated)')
+    ap.add_argument('-k', '--num', type=int, default=30)
+    ap.add_argument('--repos-dir', default='./repos', help='shared checkouts dir')
+    ap.add_argument('--out-dir', default='./results_k')
+    ap.add_argument('--src-dir',
+                    help='parent of <Project>-<bug>/{buggy,fixed,source_*}; '
+                         'copies checkouts from here and is used as --solutions-dir')
+    ap.add_argument('--solutions-dir', help='override (default: --src-dir)')
+    ap.add_argument('--seed', type=int, default=42)
+    ap.add_argument('--include-test-changes', action='store_true')
+    args = ap.parse_args()
+
+    models = []
+    for m in args.models:
+        models += [x for x in m.split(',') if x]
+    solutions_dir = args.solutions_dir or args.src_dir
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    os.makedirs(args.repos_dir, exist_ok=True)
+
+    bugs = csv_data.load_incorrect(args.csv)
+    selected = select_diverse(bugs, args.num, args.seed)
+    n_proj = len(set(b.rsplit('-', 1)[0] for b in selected))
+    plog.log(f'selected {len(selected)}/{len(bugs)} bugs across {n_proj} projects '
+             f'(seed={args.seed})')
+    plog.log(f'  {selected}')
+
+    sel_csv = path.join(args.out_dir, 'selected_bugs.csv')
+    write_filtered_csv(args.csv, selected, sel_csv)
+
+    plog.log('=== checkouts (shared) ===')
+    ensure_checkouts(args.repos_dir, selected, bugs, args.src_dir)
+
+    plog.log('=== build buggy_<llm> (shared) ===')
+    prep = [sys.executable, path.join(HERE, 'prepare_patched.py'),
+            '--csv', sel_csv, '--repos-dir', args.repos_dir]
+    if solutions_dir:
+        prep += ['--solutions-dir', solutions_dir]
+    if args.include_test_changes:
+        prep += ['--include-test-changes']
+    run(prep)
+
+    summary = {}
+    for model in models:
+        mdir = path.join(args.out_dir, model)
+        tests_dir = path.join(mdir, 'aug_tests')
+        results = path.join(mdir, 'aug_results.json')
+        os.makedirs(tests_dir, exist_ok=True)
+
+        plog.log(f'=== model {model}: generate ===')
+        run([sys.executable, path.join(HERE, 'gen_augmented.py'),
+             '--csv', sel_csv, '--repos-dir', args.repos_dir,
+             '--tests-dir', tests_dir, '--model', model])
+
+        plog.log(f'=== model {model}: evaluate ===')
+        run([sys.executable, path.join(HERE, 'eval_augmented.py'),
+             '--csv', sel_csv, '--repos-dir', args.repos_dir,
+             '--tests-dir', tests_dir, '--out', results])
+        run([sys.executable, path.join(HERE, 'report_stats.py'),
+             '--results', results, '--by-project'])
+
+        n_correct = n_total = 0
+        if path.isfile(results):
+            with open(results) as f:
+                data = json.load(f)
+            n_total = len(data)
+            n_correct = sum(1 for r in data.values() if r['correctly_augmented'])
+        cost_usd = None
+        cost_path = path.join(tests_dir, 'records', 'cost.json')
+        if path.isfile(cost_path):
+            with open(cost_path) as f:
+                cost_usd = json.load(f).get('totals', {}).get('cost_usd')
+        summary[model] = {'correct': n_correct, 'total': n_total, 'cost_usd': cost_usd}
+
+    with open(path.join(args.out_dir, 'summary.json'), 'w') as f:
+        json.dump({'k': len(selected), 'seed': args.seed,
+                   'selected': selected, 'models': summary}, f, indent=2)
+
+    plog.log('=== SUMMARY ===')
+    for model, s in summary.items():
+        cost = f"${s['cost_usd']:.4f}" if s['cost_usd'] is not None else 'n/a'
+        plog.log(f"  {model:18} correct={s['correct']}/{s['total']}  cost={cost}")
+    plog.log(f'results in {args.out_dir}/<model>/  | summary: {args.out_dir}/summary.json')
+
+
+if __name__ == '__main__':
+    main()

--- a/simple_d4j_pipeline/try_k.py
+++ b/simple_d4j_pipeline/try_k.py
@@ -147,12 +147,12 @@ def main():
         plog.log(f'=== model {model}: generate ===')
         run([sys.executable, path.join(HERE, 'gen_augmented.py'),
              '--csv', sel_csv, '--repos-dir', args.repos_dir,
-             '--tests-dir', tests_dir, '--model', model])
+             '--out-dir', args.out_dir, '--model', model])
 
         plog.log(f'=== model {model}: evaluate ===')
         run([sys.executable, path.join(HERE, 'eval_augmented.py'),
              '--csv', sel_csv, '--repos-dir', args.repos_dir,
-             '--tests-dir', tests_dir, '--out', results])
+             '--out-dir', args.out_dir, '--model', model])
         run([sys.executable, path.join(HERE, 'report_stats.py'),
              '--results', results, '--by-project'])
 

--- a/simple_d4j_pipeline/try_one.sh
+++ b/simple_d4j_pipeline/try_one.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the augmented-test pipeline end-to-end on ONE Defects4J bug.
+# Runs: checkout (buggy+fixed) -> build buggy_<llm> -> generate test -> evaluate.
+#
+# Usage:
+#   OPENAI_API_KEY=... bash try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL]
+#
+# Examples:
+#   OPENAI_API_KEY=sk-... bash try_one.sh Chart 16
+#   bash try_one.sh Lang 6 /tmp/repos /tmp/aug_tests
+#
+# The bug must have >=1 incorrect LLM patch in the CSV, otherwise steps 2-4
+# will report 0 targets. Set JDK 8 first for Defects4J.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PID="${1:?usage: try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL]}"
+BUG="${2:?usage: try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL]}"
+REPOS_DIR="${3:-$(pwd)/repos}"
+TESTS_DIR="${4:-$(pwd)/aug_tests}"
+CSV="${5:-$HERE/data/LLM_patch_manual_evaluation.csv}"
+MODEL="${6:-gpt-5.4-mini}"
+
+echo "### bug=${PID}-${BUG}  repos=${REPOS_DIR}  tests=${TESTS_DIR}  model=${MODEL}"
+
+echo "### [1/4] checkout buggy + fixed"
+mkdir -p "$REPOS_DIR"
+[ -d "$REPOS_DIR/${PID}_${BUG}b" ] || defects4j checkout -p "$PID" -v "${BUG}b" -w "$REPOS_DIR/${PID}_${BUG}b"
+[ -d "$REPOS_DIR/${PID}_${BUG}f" ] || defects4j checkout -p "$PID" -v "${BUG}f" -w "$REPOS_DIR/${PID}_${BUG}f"
+
+echo "### [2/4] build buggy_<llm> from incorrect patch(es)"
+python "$HERE/prepare_patched.py" --csv "$CSV" --repos-dir "$REPOS_DIR" -p "$PID" -b "$BUG"
+
+echo "### [3/4] generate augmented test (OpenAI)"
+python "$HERE/gen_augmented.py" --csv "$CSV" --repos-dir "$REPOS_DIR" \
+    --tests-dir "$TESTS_DIR" -p "$PID" -b "$BUG" --model "$MODEL" --save-prompts
+
+echo "### [4/4] evaluate on buggy / fixed / buggy_<llm>"
+python "$HERE/eval_augmented.py" --csv "$CSV" --repos-dir "$REPOS_DIR" \
+    --tests-dir "$TESTS_DIR" -p "$PID" -b "$BUG" \
+    --out "$TESTS_DIR/${PID}_${BUG}_result.json"
+
+echo "### result JSON: $TESTS_DIR/${PID}_${BUG}_result.json"
+cat "$TESTS_DIR/${PID}_${BUG}_result.json"

--- a/simple_d4j_pipeline/try_one.sh
+++ b/simple_d4j_pipeline/try_one.sh
@@ -4,11 +4,13 @@
 # Runs: checkout (buggy+fixed) -> build buggy_<llm> -> generate test -> evaluate.
 #
 # Usage:
-#   OPENAI_API_KEY=... bash try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL]
+#   OPENAI_API_KEY=... bash try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL] [PRICE_IN] [PRICE_OUT]
+#
+# PRICE_IN / PRICE_OUT are USD per 1M input/output tokens (for cost tracking).
 #
 # Examples:
 #   OPENAI_API_KEY=sk-... bash try_one.sh Chart 16
-#   bash try_one.sh Lang 6 /tmp/repos /tmp/aug_tests
+#   bash try_one.sh Lang 6 /tmp/repos /tmp/aug_tests "" gpt-5.4-mini 0.25 2.00
 #
 # The bug must have >=1 incorrect LLM patch in the CSV, otherwise steps 2-4
 # will report 0 targets. Set JDK 8 first for Defects4J.
@@ -16,12 +18,18 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-PID="${1:?usage: try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL]}"
-BUG="${2:?usage: try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL]}"
+PID="${1:?usage: try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL] [PRICE_IN] [PRICE_OUT]}"
+BUG="${2:?usage: try_one.sh <Project> <bug> [REPOS_DIR] [TESTS_DIR] [CSV] [MODEL] [PRICE_IN] [PRICE_OUT]}"
 REPOS_DIR="${3:-$(pwd)/repos}"
 TESTS_DIR="${4:-$(pwd)/aug_tests}"
 CSV="${5:-$HERE/data/LLM_patch_manual_evaluation.csv}"
 MODEL="${6:-gpt-5.4-mini}"
+PRICE_IN="${7:-}"
+PRICE_OUT="${8:-}"
+
+PRICE_ARGS=()
+[ -n "$PRICE_IN" ] && PRICE_ARGS+=(--price-in "$PRICE_IN")
+[ -n "$PRICE_OUT" ] && PRICE_ARGS+=(--price-out "$PRICE_OUT")
 
 echo "### bug=${PID}-${BUG}  repos=${REPOS_DIR}  tests=${TESTS_DIR}  model=${MODEL}"
 
@@ -35,7 +43,8 @@ python "$HERE/prepare_patched.py" --csv "$CSV" --repos-dir "$REPOS_DIR" -p "$PID
 
 echo "### [3/4] generate augmented test (OpenAI)"
 python "$HERE/gen_augmented.py" --csv "$CSV" --repos-dir "$REPOS_DIR" \
-    --tests-dir "$TESTS_DIR" -p "$PID" -b "$BUG" --model "$MODEL" --save-prompts
+    --tests-dir "$TESTS_DIR" -p "$PID" -b "$BUG" --model "$MODEL" --save-prompts \
+    ${PRICE_ARGS[@]+"${PRICE_ARGS[@]}"}
 
 echo "### [4/4] evaluate on buggy / fixed / buggy_<llm>"
 python "$HERE/eval_augmented.py" --csv "$CSV" --repos-dir "$REPOS_DIR" \
@@ -44,3 +53,8 @@ python "$HERE/eval_augmented.py" --csv "$CSV" --repos-dir "$REPOS_DIR" \
 
 echo "### result JSON: $TESTS_DIR/${PID}_${BUG}_result.json"
 cat "$TESTS_DIR/${PID}_${BUG}_result.json"
+echo
+echo "### cost summary: $TESTS_DIR/records/cost.json"
+cat "$TESTS_DIR/records/cost.json" 2>/dev/null || echo "(no cost file)"
+echo
+echo "### full per-bug record: $TESTS_DIR/records/${PID}_${BUG}.json"

--- a/simple_d4j_pipeline/try_one.sh
+++ b/simple_d4j_pipeline/try_one.sh
@@ -31,17 +31,30 @@ PRICE_ARGS=()
 [ -n "$PRICE_IN" ] && PRICE_ARGS+=(--price-in "$PRICE_IN")
 [ -n "$PRICE_OUT" ] && PRICE_ARGS+=(--price-out "$PRICE_OUT")
 
-# Optional: env SOLUTIONS_DIR = on-disk path to /data/d4j_subjects/d4j_bugs,
-# enabling full-file LLM solution replacement (robust vs. the reformatted diffs).
+# Optional: env SRC_DIR = parent dir holding <Project>-<bug>/{buggy,fixed} and
+# the LLM solution dirs (matching /data/d4j_subjects/d4j_bugs). When set, buggy/
+# fixed are copied from there (no defects4j checkout) and SOLUTIONS_DIR defaults
+# to it for full-file LLM solution replacement.
+SRC_DIR="${SRC_DIR:-}"
+SOLUTIONS_DIR="${SOLUTIONS_DIR:-$SRC_DIR}"
 PREP_ARGS=()
-[ -n "${SOLUTIONS_DIR:-}" ] && PREP_ARGS+=(--solutions-dir "$SOLUTIONS_DIR")
+[ -n "$SOLUTIONS_DIR" ] && PREP_ARGS+=(--solutions-dir "$SOLUTIONS_DIR")
 
 echo "### bug=${PID}-${BUG}  repos=${REPOS_DIR}  tests=${TESTS_DIR}  model=${MODEL}"
 
-echo "### [1/4] checkout buggy + fixed"
+echo "### [1/4] obtain buggy + fixed"
 mkdir -p "$REPOS_DIR"
-[ -d "$REPOS_DIR/${PID}_${BUG}b" ] || defects4j checkout -p "$PID" -v "${BUG}b" -w "$REPOS_DIR/${PID}_${BUG}b"
-[ -d "$REPOS_DIR/${PID}_${BUG}f" ] || defects4j checkout -p "$PID" -v "${BUG}f" -w "$REPOS_DIR/${PID}_${BUG}f"
+for pair in buggy:b fixed:f; do
+    sub="${pair%%:*}"; suf="${pair##*:}"
+    dest="$REPOS_DIR/${PID}_${BUG}${suf}"
+    [ -d "$dest" ] && continue
+    if [ -n "$SRC_DIR" ] && [ -d "$SRC_DIR/${PID}-${BUG}/$sub" ]; then
+        cp -a "$SRC_DIR/${PID}-${BUG}/$sub" "$dest"
+        echo "    copied $SRC_DIR/${PID}-${BUG}/$sub -> $(basename "$dest")"
+    else
+        defects4j checkout -p "$PID" -v "${BUG}${suf}" -w "$dest"
+    fi
+done
 
 echo "### [2/4] build buggy_<llm> from incorrect patch(es)"
 python "$HERE/prepare_patched.py" --csv "$CSV" --repos-dir "$REPOS_DIR" -p "$PID" -b "$BUG" \

--- a/simple_d4j_pipeline/try_one.sh
+++ b/simple_d4j_pipeline/try_one.sh
@@ -38,7 +38,14 @@ PRICE_ARGS=()
 SRC_DIR="${SRC_DIR:-}"
 SOLUTIONS_DIR="${SOLUTIONS_DIR:-$SRC_DIR}"
 PREP_ARGS=()
-[ -n "$SOLUTIONS_DIR" ] && PREP_ARGS+=(--solutions-dir "$SOLUTIONS_DIR")
+if [ -n "$SOLUTIONS_DIR" ]; then
+    PREP_ARGS+=(--solutions-dir "$SOLUTIONS_DIR")
+else
+    echo "### WARNING: no SRC_DIR/SOLUTIONS_DIR set -> prepare_patched.py will fall"
+    echo "###          back to diff application, which fails on these reformatted"
+    echo "###          patches. Set SRC_DIR to the parent of the <Project>-<bug>"
+    echo "###          dirs (e.g. SRC_DIR=..) to copy full LLM solution files."
+fi
 
 echo "### bug=${PID}-${BUG}  repos=${REPOS_DIR}  tests=${TESTS_DIR}  model=${MODEL}"
 

--- a/simple_d4j_pipeline/try_one.sh
+++ b/simple_d4j_pipeline/try_one.sh
@@ -31,6 +31,11 @@ PRICE_ARGS=()
 [ -n "$PRICE_IN" ] && PRICE_ARGS+=(--price-in "$PRICE_IN")
 [ -n "$PRICE_OUT" ] && PRICE_ARGS+=(--price-out "$PRICE_OUT")
 
+# Optional: env SOLUTIONS_DIR = on-disk path to /data/d4j_subjects/d4j_bugs,
+# enabling full-file LLM solution replacement (robust vs. the reformatted diffs).
+PREP_ARGS=()
+[ -n "${SOLUTIONS_DIR:-}" ] && PREP_ARGS+=(--solutions-dir "$SOLUTIONS_DIR")
+
 echo "### bug=${PID}-${BUG}  repos=${REPOS_DIR}  tests=${TESTS_DIR}  model=${MODEL}"
 
 echo "### [1/4] checkout buggy + fixed"
@@ -39,7 +44,8 @@ mkdir -p "$REPOS_DIR"
 [ -d "$REPOS_DIR/${PID}_${BUG}f" ] || defects4j checkout -p "$PID" -v "${BUG}f" -w "$REPOS_DIR/${PID}_${BUG}f"
 
 echo "### [2/4] build buggy_<llm> from incorrect patch(es)"
-python "$HERE/prepare_patched.py" --csv "$CSV" --repos-dir "$REPOS_DIR" -p "$PID" -b "$BUG"
+python "$HERE/prepare_patched.py" --csv "$CSV" --repos-dir "$REPOS_DIR" -p "$PID" -b "$BUG" \
+    ${PREP_ARGS[@]+"${PREP_ARGS[@]}"}
 
 echo "### [3/4] generate augmented test (OpenAI)"
 python "$HERE/gen_augmented.py" --csv "$CSV" --repos-dir "$REPOS_DIR" \


### PR DESCRIPTION
Standalone scripts for evaluating bare LLM-generated JUnit test methods across all Defects4J bugs, distilled from libro's run/postprocess logic:

- checkout_all.sh: checkout buggy (Xb) and fixed (Xf) versions of every bug
- injector.py: resolve imports and inject a test method into the best-matching existing test class (ported/trimmed from common.py)
- run_pipeline.py: inject/compile/run each candidate on both versions and flag fail-in-buggy / pass-in-fixed reproductions

Uses `defects4j export` for source/test dirs instead of hardcoded path maps, and standard b/f checkouts instead of custom compilable git tags.

https://claude.ai/code/session_019EN4GSkHR15i1vwioj8RNa